### PR TITLE
Compiler warnings removed by making local instances of typedefs unique

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -149,22 +149,22 @@ typename TransformType::Pointer DoCenteredInitialization(
     }
   else if( initializeTransformMode == "useCenterOfROIAlign" )
     {
-    typedef typename itk::ImageMaskSpatialObject<FixedImageType::ImageDimension> ImageMaskSpatialObjectType;
-    typedef itk::Image<unsigned char, 3>                                         MaskImageType;
+    typedef typename itk::ImageMaskSpatialObject<FixedImageType::ImageDimension> CROIImageMaskSpatialObjectType;
+    typedef itk::Image<unsigned char, 3>                                         CROIMaskImageType;
     typename MovingImageType::PointType movingCenter;
     typename FixedImageType::PointType fixedCenter;
 
-    typename ImageMaskSpatialObjectType::Pointer movingImageMask(
-      dynamic_cast<ImageMaskSpatialObjectType *>( movingMask.GetPointer() ) );
-    typename MaskImageType::Pointer tempOutputMovingVolumeROI =
-      const_cast<MaskImageType *>( movingImageMask->GetImage() );
+    typename CROIImageMaskSpatialObjectType::Pointer movingImageMask(
+      dynamic_cast<CROIImageMaskSpatialObjectType *>( movingMask.GetPointer() ) );
+    typename CROIMaskImageType::Pointer tempOutputMovingVolumeROI =
+      const_cast<CROIMaskImageType *>( movingImageMask->GetImage() );
 
-    typename ImageMaskSpatialObjectType::Pointer fixedImageMask(
-      dynamic_cast<ImageMaskSpatialObjectType *>( fixedMask.GetPointer() ) );
-    typename MaskImageType::Pointer tempOutputFixedVolumeROI =
-      const_cast<MaskImageType *>( fixedImageMask->GetImage() );
-    typedef itk::CastImageFilter<MaskImageType, FixedImageType>  MaskToFixedCastType;
-    typedef itk::CastImageFilter<MaskImageType, MovingImageType> MaskToMovingCastType;
+    typename CROIImageMaskSpatialObjectType::Pointer fixedImageMask(
+      dynamic_cast<CROIImageMaskSpatialObjectType *>( fixedMask.GetPointer() ) );
+    typename CROIMaskImageType::Pointer tempOutputFixedVolumeROI =
+      const_cast<CROIMaskImageType *>( fixedImageMask->GetImage() );
+    typedef itk::CastImageFilter<CROIMaskImageType, FixedImageType>  MaskToFixedCastType;
+    typedef itk::CastImageFilter<CROIMaskImageType, MovingImageType> MaskToMovingCastType;
 
     typename MaskToFixedCastType::Pointer mask2fixedCast = MaskToFixedCastType::New();
     typename MaskToMovingCastType::Pointer mask2movingCast = MaskToMovingCastType::New();
@@ -189,8 +189,7 @@ typename TransformType::Pointer DoCenteredInitialization(
     }
   else if( initializeTransformMode == "useCenterOfHeadAlign" )
     {
-    typedef typename itk::ImageMaskSpatialObject<FixedImageType::ImageDimension> ImageMaskSpatialObjectType;
-    typedef itk::Image<unsigned char, 3>                                         MaskImageType;
+    typedef itk::Image<unsigned char, 3>                                         CHMMaskImageType;
     typename MovingImageType::PointType movingCenter;
     typename FixedImageType::PointType fixedCenter;
 
@@ -207,22 +206,19 @@ typename TransformType::Pointer DoCenteredInitialization(
       {
       typename ImageMaskSpatialObjectType::Pointer movingImageMask(
         dynamic_cast<ImageMaskSpatialObjectType *>( movingMask.GetPointer() ) );
-      typename MaskImageType::Pointer tempOutputMovingVolumeROI =
-        const_cast<MaskImageType *>( movingImageMask->GetImage() );
+      typename CHMMaskImageType::Pointer tempOutputMovingVolumeROI =
+        const_cast<CHMMaskImageType *>( movingImageMask->GetImage() );
       movingFindCenter->SetImageMask(tempOutputMovingVolumeROI);
       }
     movingFindCenter->Update();
     movingCenter = movingFindCenter->GetCenterOfBrain();
       {
       // convert mask image to mask
-      typedef typename itk::ImageMaskSpatialObject<Dimension>
-      ImageMaskSpatialObjectType;
-      typename ImageMaskSpatialObjectType::Pointer mask =
-        ImageMaskSpatialObjectType::New();
+      typename ImageMaskSpatialObjectType::Pointer mask = ImageMaskSpatialObjectType::New();
       mask->SetImage( movingFindCenter->GetClippedImageMask() );
 
-      typename MaskImageType::Pointer ClippedMask = movingFindCenter->GetClippedImageMask();
-      // itkUtil::WriteImage<MaskImageType>( ClippedMask ,
+      typename CHMMaskImageType::Pointer ClippedMask = movingFindCenter->GetClippedImageMask();
+      // itkUtil::WriteImage<CHMMaskImageType>( ClippedMask ,
       // std::string("MOVING_MASK.nii.gz"));
 
       mask->ComputeObjectToWorldTransform();
@@ -243,8 +239,8 @@ typename TransformType::Pointer DoCenteredInitialization(
       {
       typename ImageMaskSpatialObjectType::Pointer fixedImageMask(
         dynamic_cast<ImageMaskSpatialObjectType *>( fixedMask.GetPointer() ) );
-      typename MaskImageType::Pointer tempOutputFixedVolumeROI =
-        const_cast<MaskImageType *>( fixedImageMask->GetImage() );
+      typename CHMMaskImageType::Pointer tempOutputFixedVolumeROI =
+        const_cast<CHMMaskImageType *>( fixedImageMask->GetImage() );
       fixedFindCenter->SetImageMask(tempOutputFixedVolumeROI);
       }
     fixedFindCenter->Update();
@@ -252,11 +248,10 @@ typename TransformType::Pointer DoCenteredInitialization(
 
       {
       // convert mask image to mask
-      typedef typename itk::ImageMaskSpatialObject<Dimension> ImageMaskSpatialObjectType;
       typename ImageMaskSpatialObjectType::Pointer mask = ImageMaskSpatialObjectType::New();
       mask->SetImage( fixedFindCenter->GetClippedImageMask() );
 
-      typename MaskImageType::Pointer ClippedMask = fixedFindCenter->GetClippedImageMask();
+      typename CHMMaskImageType::Pointer ClippedMask = fixedFindCenter->GetClippedImageMask();
 
       mask->ComputeObjectToWorldTransform();
       typename SpatialObjectType::Pointer p = dynamic_cast<SpatialObjectType *>( mask.GetPointer() );
@@ -713,8 +708,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::StartRegistration(void
       m_MaskInferiorCutOffFromCenter);
 
       {   // Write out some debugging information if requested
-      typedef itk::Image<unsigned char, 3>                               MaskImageType;
-      typedef itk::ImageMaskSpatialObject<MaskImageType::ImageDimension> ImageMaskSpatialObjectType;
       if( ( !this->m_FixedBinaryVolume.IsNull() ) && ( m_OutputFixedVolumeROI != "" ) )
         {
         const MaskImageType::ConstPointer tempOutputFixedVolumeROI =

--- a/BRAINSCommonLib/BRAINSFitUtils.h
+++ b/BRAINSCommonLib/BRAINSFitUtils.h
@@ -60,10 +60,7 @@ void DoCenteredTransformMaskClipping(
     }
   std::cerr << "maskInferiorCutOffFromCenter is " << maskInferiorCutOffFromCenter << std::endl;
 
-  typedef itk::ImageMaskSpatialObject<VImageDimension> ImageMaskSpatialObjectType;
-
   typedef unsigned char                          PixelType;
-  typedef itk::Image<PixelType, VImageDimension> MaskImageType;
 
   typename TransformType::InputPointType rotationCenter = transform->GetCenter();
   typename TransformType::OutputVectorType translationVector = transform->GetTranslation();

--- a/BRAINSCommonLib/GenericTransformImage.hxx
+++ b/BRAINSCommonLib/GenericTransformImage.hxx
@@ -353,13 +353,12 @@ typename OutputImageType::Pointer GenericTransformImage(
     // A special case for dealing with binary images
     // where signed distance maps are warped and thresholds created
     typedef short int                                                                    MaskPixelType;
-    typedef typename itk::Image<MaskPixelType,  GenericTransformImageNS::SpaceDimension> MaskImageType;
+    typedef typename itk::Image<MaskPixelType,  GenericTransformImageNS::SpaceDimension> BinFlagOnMaskImageType;
 
     // Now Threshold and write out image
     typedef typename itk::BinaryThresholdImageFilter<InputImageType,
-                                                     MaskImageType> BinaryThresholdFilterType;
-    typename BinaryThresholdFilterType::Pointer finalFilter =
-      BinaryThresholdFilterType::New();
+                                                     BinFlagOnMaskImageType> BinaryThresholdFilterType;
+    typename BinaryThresholdFilterType::Pointer finalFilter = BinaryThresholdFilterType::New();
     finalFilter->SetInput(TransformedImage);
 
     const typename BinaryThresholdFilterType::OutputPixelType outsideValue = 0;
@@ -381,7 +380,7 @@ typename OutputImageType::Pointer GenericTransformImage(
 
     finalFilter->Update();
 
-    typedef typename itk::CastImageFilter<MaskImageType, InputImageType> CastImageFilter;
+    typedef typename itk::CastImageFilter<BinFlagOnMaskImageType, InputImageType> CastImageFilter;
     typename CastImageFilter::Pointer castFilter = CastImageFilter::New();
     castFilter->SetInput( finalFilter->GetOutput() );
     castFilter->Update();

--- a/BRAINSCommonLib/ReadMask.h
+++ b/BRAINSCommonLib/ReadMask.h
@@ -9,18 +9,16 @@ typename MaskType::Pointer
 ReadImageMask(const std::string & filename,
               typename itk::ImageBase<VDimension> * /*referenceImage*/)
 {
-  typedef unsigned char                                  MaskPixelType;
-  typedef typename itk::Image<MaskPixelType, VDimension> MaskImageType;
-  typename MaskImageType::Pointer OrientedMaskImage = NULL;
+  typedef unsigned char                MaskPixelType;
+  typedef itk::Image<MaskPixelType, 3> ReadMaskImageType;
+  typename ReadMaskImageType::Pointer OrientedMaskImage = NULL;
 
-  OrientedMaskImage = itkUtil::ReadImage<MaskImageType>(filename);
+  OrientedMaskImage = itkUtil::ReadImage<ReadMaskImageType>(filename);
   // TODO:  May want to check that physical spaces overlap?
 
   // convert mask image to mask
-  typedef typename itk::ImageMaskSpatialObject<VDimension>
-  ImageMaskSpatialObjectType;
-  typename ImageMaskSpatialObjectType::Pointer mask =
-    ImageMaskSpatialObjectType::New();
+  typedef itk::ImageMaskSpatialObject<ReadMaskImageType::ImageDimension> ReadImageMaskSpatialObjectType;
+  typename ReadImageMaskSpatialObjectType::Pointer mask = ReadImageMaskSpatialObjectType::New();
   mask->SetImage(OrientedMaskImage);
   //
   mask->ComputeObjectToWorldTransform();

--- a/BRAINSCommonLib/itkFindCenterOfBrainFilter.hxx
+++ b/BRAINSCommonLib/itkFindCenterOfBrainFilter.hxx
@@ -368,8 +368,8 @@ FindCenterOfBrainFilter<TInputImage, TMaskImage>
     moments->SetImage(this->m_TrimmedImage);
       {
       // convert mask image to mask
-      typedef typename itk::ImageMaskSpatialObject<TInputImage::ImageDimension> ImageMaskSpatialObjectType;
-      typename ImageMaskSpatialObjectType::Pointer mask = ImageMaskSpatialObjectType::New();
+      typedef typename itk::ImageMaskSpatialObject<TInputImage::ImageDimension> LFFImageMaskSpatialObjectType;
+      typename LFFImageMaskSpatialObjectType::Pointer mask = LFFImageMaskSpatialObjectType::New();
       mask->SetImage(this->m_ClippedImageMask);
       mask->ComputeObjectToWorldTransform();
       typename itk::SpatialObject<TInputImage::ImageDimension>::Pointer test =

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -26,15 +26,15 @@ PURPOSE.  See the above copyright notices for more information.
 // Insight/Examples/Registration/ImageRegistration8.cxx
 // and is an improved replacement for the old (and defective)
 
-typedef float                            PixelType;
-typedef itk::Image<PixelType, Dimension> FixedVolumeType;
-typedef itk::Image<PixelType, Dimension> MovingVolumeType;
+typedef float                            BRAINSFitPixelType;
+typedef itk::Image<BRAINSFitPixelType, Dimension> FixedVolumeType;
+typedef itk::Image<BRAINSFitPixelType, Dimension> MovingVolumeType;
 
-typedef itk::Image<PixelType, MaxInputDimension> InputImageType;
+typedef itk::Image<BRAINSFitPixelType, MaxInputDimension> InputImageType;
 typedef itk::ImageFileReader<InputImageType>     FixedVolumeReaderType;
 typedef itk::ImageFileReader<InputImageType>     MovingVolumeReaderType;
 typedef AffineTransformType::Pointer             AffineTransformPointer;
-typedef itk::Vector<double, Dimension>           VectorType;
+//typedef itk::Vector<double, Dimension>           BRAINSFitVectorType;
 
 // This function deciphers the BackgroundFillValueString and returns a double
 // precision number based on the requested value


### PR DESCRIPTION
Compiler warnings issued due to shadowed typedefs.
