### PR TITLE
Updating Slicer Documentation Strings

### DIFF
--- a/BRAINSDemonWarp/BRAINSDemonWarp.xml
+++ b/BRAINSDemonWarp/BRAINSDemonWarp.xml
@@ -8,7 +8,7 @@
 
   </description>
   <version>3.0.0</version>
-  <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Modules:BRAINSDemonWarp</documentation-url>
+  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSDemonWarp</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
   <contributor>This tool was developed by Hans J. Johnson and Greg Harris.</contributor>
   <acknowledgements>The development of this tool was supported by funding from grants NS050568 and NS40068 from the National Institute of Neurological Disorders and Stroke and grants MH31593, MH40856, from the National Institute of Mental Health.  </acknowledgements>

--- a/BRAINSDemonWarp/VBRAINSDemonWarp.xml
+++ b/BRAINSDemonWarp/VBRAINSDemonWarp.xml
@@ -8,7 +8,7 @@
 
   </description>
   <version>3.0.0</version>
-  <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Modules:BRAINSDemonWarp</documentation-url>
+  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSDemonWarp</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
   <contributor>This tool was developed by Hans J. Johnson and Greg Harris.</contributor>
   <acknowledgements>The development of this tool was supported by funding from grants NS050568 and NS40068 from the National Institute of Neurological Disorders and Stroke and grants MH31593, MH40856, from the National Institute of Mental Health.  </acknowledgements>

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -3,7 +3,7 @@
   <category>Registration</category>
   <title>General Registration (BRAINS)</title>
   <description>Register a three-dimensional volume to a reference volume (Mattes Mutual Information by default). Full documentation avalable here: http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSFit. Method described in BRAINSFit: Mutual Information Registrations of Whole-Brain 3D Images, Using the Insight Toolkit, Johnson H.J., Harris G., Williams K., The Insight Journal, 2007. http://hdl.handle.net/1926/1291</description>
-  <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Modules:BRAINSFit</documentation-url>
+  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSFit</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
   <contributor>Hans J. Johnson, hans-johnson -at- uiowa.edu, http://wwww.psychiatry.uiowa.edu</contributor>
   <acknowledgements><![CDATA[Hans Johnson(1,3,4); Kent Williams(1); Gregory Harris(1), Vincent Magnotta(1,2,3);  Andriy Fedorov(5) 1=University of Iowa Department of Psychiatry, 2=University of Iowa Department of Radiology, 3=University of Iowa Department of Biomedical Engineering, 4=University of Iowa Department of Electrical and Computer Engineering, 5=Surgical Planning Lab, Harvard]]>  </acknowledgements>

--- a/BRAINSResample/BRAINSResample.xml
+++ b/BRAINSResample/BRAINSResample.xml
@@ -7,7 +7,7 @@
 	  This program collects together three common image processing tasks that all involve resampling an image volume: Resampling to a new resolution and spacing, applying a transformation (using an ITK transform IO mechanisms) and Warping (using a vector image deformation field).  Full documentation available here: http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSResample.
   </description>
   <version>3.0.0</version>
-  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Modules:BRAINSResample</documentation-url>
+  <documentation-url>http://www.slicer.org/slicerWiki/index.php/Documentation/4.0/Modules/BRAINSResample</documentation-url>
   <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
   <contributor>This tool was developed by Vincent Magnotta, Greg Harris, and Hans Johnson.</contributor>
   <acknowledgements>The development of this tool was supported by funding from grants NS050568 and NS40068 from the National Institute of Neurological Disorders and Stroke and grants MH31593, MH40856, from the National Institute of Mental Health.  </acknowledgements>


### PR DESCRIPTION
Hello All,
I was tasked with updating the Slicer Wiki URLs to point to the documentation for 4.0 rather than 3.6.  The 4 XML files that I changed still had references to the 3.6 pages when a 4.0 page was available.  This is done so the hyper-link in the 'Help' window of Slicer takes you to the correct page.
Part of: http://www.na-mic.org/Bug/view.php?id=1675

Thanks.
