### PR TITLE
Another issue on the noise generator

### DIFF
--- a/BRAINSCut/BRAINSFeatureCreators/CMakeLists.txt
+++ b/BRAINSCut/BRAINSFeatureCreators/CMakeLists.txt
@@ -29,3 +29,5 @@ add_subdirectory(HistogramMatchingFilter)
 add_subdirectory(TextureMeasureFilter)
 
 add_subdirectory(STAPLE)
+
+#add_subdirectory(NoiseGenerator)

--- a/BRAINSCut/BRAINSFeatureCreators/CMakeLists.txt
+++ b/BRAINSCut/BRAINSFeatureCreators/CMakeLists.txt
@@ -30,4 +30,5 @@ add_subdirectory(TextureMeasureFilter)
 
 add_subdirectory(STAPLE)
 
-#add_subdirectory(NoiseGenerator)
+add_subdirectory(NoiseGenerator)
+add_subdirectory(DumpBinaryTrainingVectors)

--- a/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/CMakeLists.txt
+++ b/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(DumpBinaryTrainingVectors)
+
+## Build all the programs
+##
+set(ALL_PROGS_LIST
+  ${PROJECT_NAME}
+  )
+foreach( prog ${ALL_PROGS_LIST} )
+  StandardBRAINSBuildMacro( NAME ${prog} TARGET_LIBRARIES ${ITK_LIBRARIES} )
+endforeach()

--- a/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/DumpBinaryTrainingVectors.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/DumpBinaryTrainingVectors.cxx
@@ -2,6 +2,9 @@
 #include <fstream>
 #include <sstream>
 
+#include "DumpBinaryTrainingVectorsCLP.h"
+#define MAX_LINE_SIZE 1000
+#define LineGuard  1234567.0
 void
 ReadHeader(const char *fname,
            unsigned int & InputVectorSize,
@@ -13,8 +16,9 @@ ReadHeader(const char *fname,
   filestr.open(fname);
   if( !filestr.is_open() )
     {
-    itkGenericExceptionMacro(<< "Error: Could not open ANN vector file"
-                             << fname);
+      std::cout<<"Error: Could not open ANN vector file"
+               << fname 
+               << std::endl;
     }
   for( int tags = 0; tags < 3; tags++ )
     {
@@ -42,6 +46,8 @@ ReadHeader(const char *fname,
 int
 main(int argc, char * *argv)
 {
+  PARSE_ARGS;
+
   unsigned int InputVectorSize;
   unsigned int OutputVectorSize;
   unsigned int NumberTrainingVectorsFromFile;
@@ -56,7 +62,7 @@ main(int argc, char * *argv)
   // read header
   try
     {
-    ReadHeader(argv[1],
+    ReadHeader( inputHeaderFilename.c_str(),
                InputVectorSize,
                OutputVectorSize,
                NumberTrainingVectorsFromFile);
@@ -65,30 +71,20 @@ main(int argc, char * *argv)
               << " #Training Vectors " << NumberTrainingVectorsFromFile
               << std::endl;
     }
-  catch(itk::ExceptionObject &ex)
+  catch( std::exception &ex)
     {
-    std::cerr << ex << std::endl;
+    std::cerr << ex.what() << std::endl;
     return EXIT_FAILURE;
     }
   // read binary
   // const unsigned int OutputVectorSize=2;
   const unsigned int SentinalValueSize = 1;
   std::ifstream      binfile;
-  binfile.open(argv[2], std::ios::in | std::ios::binary);
+  binfile.open(inputVectorFilename.c_str(), std::ios::in | std::ios::binary);
   if( !binfile.is_open() )
     {
-    std::cerr << "Can't open " << argv[2] << std::endl;
+    std::cerr << "Can't open " << inputVectorFilename << std::endl;
     return EXIT_FAILURE;
-    }
-  unsigned skip = 0;
-  if( argc > 3 )
-    {
-    skip = atoi(argv[3]);
-    }
-  if( skip > 0 )
-    {
-    std::cout << "Skipping " << skip << " vectors"
-              << std::endl;
     }
   unsigned int recordsize =
     ( InputVectorSize + OutputVectorSize
@@ -123,7 +119,7 @@ main(int argc, char * *argv)
 
     std::cout << std::endl;
     if( buf[OutputVectorSize + InputVectorSize + SentinalValueSize - 1] !=
-        AUTOSEG_VEC_SENTINEL )
+        LineGuard)
       {
       std::cerr << "Record not properly terminated by sentinel value"
                 << std::endl;

--- a/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/DumpBinaryTrainingVectors.xml
+++ b/BRAINSCut/BRAINSFeatureCreators/DumpBinaryTrainingVectors/DumpBinaryTrainingVectors.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+  <executable>
+  <category>Filtering.FeatureDetection</category>
+  <title>Erode Image</title>
+
+  <description>Uses mathematical morphology to erode the input images.</description>
+  <version>0.1.0.$Revision: 1 $(alpha)</version>
+  <documentation-url>http:://www.na-mic.org/</documentation-url>
+  <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
+  <contributor>This tool was developed by Mark Scully and Jeremy Bockholt.</contributor>
+
+
+  <parameters>
+    <label>Input Parameters</label>
+    <description>Input parameters for analysis.</description>
+
+    <image>
+      <name>inputHeaderFilename</name>
+      <longflag>--inputHeaderFilename</longflag>
+      <description>Required: input header file name</description>
+      <label>Input Header Filename </label>
+      <channel>input</channel>
+    </image>
+
+    <image>
+      <name>inputVectorFilename</name>
+      <longflag>--inputVectorFilename</longflag>
+      <description>Required: input vector filename</description>
+      <label>Input Vector Filename</label>
+      <channel>input</channel>
+    </image>
+  </parameters>
+
+  <parameters>
+    <label>Output Parameters</label>
+    <description>Output parameters for analysis.</description>
+    <image>
+      <name>outputFilename</name>
+      <longflag>--outputFilename</longflag>
+      <description>output filename (DOES NOT WORK YET)</description>
+      <label>Output Filename</label>
+      <channel>output</channel>
+    </image>
+  </parameters>
+  </executable>

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/CMakeLists.txt
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(NoiseGenerator)
+
+## Build all the programs
+##
+set(ALL_PROGS_LIST
+  ${PROJECT_NAME}
+  )
+foreach( prog ${ALL_PROGS_LIST} )
+  StandardBRAINSBuildMacro( NAME ${prog} TARGET_LIBRARIES ${ITK_LIBRARIES} )
+endforeach()

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
 
   const int dim = 3;
   
-  typedef unsigned char PixelType;
+  typedef float PixelType;
   typedef itk::Image< PixelType, dim > ImageType;
 
   typedef itk::ImageFileReader< ImageType > ReaderType;
@@ -41,6 +41,7 @@ int main(int argc, char * argv[])
 
 
   filter->SetMean( inputGaussianMean );
+  filter->Update();
 
   itk::SimpleFilterWatcher watcher(filter, "filter");
 

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
@@ -1,0 +1,55 @@
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkSimpleFilterWatcher.h"
+
+#include "itkAdditiveGaussianNoiseImageFilter.h"
+#include "NoiseGeneratorCLP.h"
+
+int main(int argc, char * argv[])
+{
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
+  PARSE_ARGS;
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
+
+  bool violated = false;
+  if( inputVolume == "" )
+    {
+    violated = true; std::cout << "  --inputVolume Required! "  << std::endl;
+    }
+  if( outputVolume == "" )
+    {
+    violated = true; std::cout << "  --outputVolume Required! "  << std::endl;
+    }
+  if( violated )
+    {
+    return EXIT_FAILURE;
+    }
+
+  const int dim = 3;
+  
+  typedef unsigned char PixelType;
+  typedef itk::Image< PixelType, dim > ImageType;
+
+  typedef itk::ImageFileReader< ImageType > ReaderType;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( inputVolume );
+
+  typedef itk::AdditiveGaussianNoiseImageFilter< ImageType, ImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput( reader->GetOutput() );
+
+  filter->SetStandardDeviation( inputGaussianStandardDeviation );
+
+  filter->SetMean( inputGaussianMean );
+
+  itk::SimpleFilterWatcher watcher(filter, "filter");
+
+  typedef itk::ImageFileWriter< ImageType > WriterType;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName( outputVolume );
+  writer->Update();
+
+  return 0;
+}
+

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
@@ -37,8 +37,8 @@ int main(int argc, char * argv[])
   typedef itk::AdditiveGaussianNoiseImageFilter< ImageType, ImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput( reader->GetOutput() );
-
   filter->SetStandardDeviation( inputGaussianStandardDeviation );
+
 
   filter->SetMean( inputGaussianMean );
 
@@ -47,7 +47,9 @@ int main(int argc, char * argv[])
   typedef itk::ImageFileWriter< ImageType > WriterType;
   WriterType::Pointer writer = WriterType::New();
   writer->SetInput( filter->GetOutput() );
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   writer->SetFileName( outputVolume );
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   writer->Update();
 
   return 0;

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.xml
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.xml
@@ -32,7 +32,7 @@
 
     <float>
       <name>inputGaussianMean</name>
-      <longflag>inputGaussianStandardDeviation</longflag>
+      <longflag>inputGaissianMean</longflag>
       <description>Optional: mean for Gaussian Noise</description>
       <label>Gaussian Mean</label>
       <default>0</default>

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.xml
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+  <executable>
+  <category>Filtering.FeatureDetection</category>
+  <title>Add Noise</title>
+
+  <description>Uses mathematical morphology to erode the input images.</description>
+  <version>0.1.0.$Revision: 1 $(alpha)</version>
+  <documentation-url>http:://www.na-mic.org/</documentation-url>
+  <license>https://www.nitrc.org/svn/brains/BuildScripts/trunk/License.txt </license>
+  <contributor>This tool was developed by Eun Young Kim.</contributor>
+
+  <parameters>
+    <label>Input Parameters</label>
+    <description>Input parameters for analysis.</description>
+
+    <image>
+      <name>inputVolume</name>
+      <longflag>inputVolume</longflag>
+      <description>Required: input image</description>
+      <label>Input Volume</label>
+      <channel>input</channel>
+    </image>
+
+    <float>
+      <name>inputGaussianStandardDeviation</name>
+      <longflag>inputGaussianStandardDeviation</longflag>
+      <description>Optional: standard deviation for Gaussian Noise</description>
+      <label>Gaussian Standard Deviation</label>
+      <default>1</default>
+      <channel>input</channel>
+    </float>
+
+    <float>
+      <name>inputGaussianMean</name>
+      <longflag>inputGaussianStandardDeviation</longflag>
+      <description>Optional: mean for Gaussian Noise</description>
+      <label>Gaussian Mean</label>
+      <default>0</default>
+      <channel>input</channel>
+    </float>
+
+  </parameters>
+  <parameters>
+    <label>Output Parameters</label>
+    <description>Output parameters for analysis.</description>
+    <image>
+      <name>outputVolume</name>
+      <longflag>outputVolume</longflag>
+      <description>Required: output image</description>
+      <label>Output Volume</label>
+      <channel>output</channel>
+    </image>
+  </parameters>
+  </executable>

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.h
@@ -1,0 +1,112 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkAdditiveGaussianNoiseImageFilter.h,v $
+  Language:  C++
+  Date:      $Date: 2009-02-24 19:03:15 $
+  Version:   $Revision: 1.4 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#ifndef __itkAdditiveGaussianNoiseImageFilter_h
+#define __itkAdditiveGaussianNoiseImageFilter_h
+
+#include "itkInPlaceImageFilter.h"
+#include "itkNumericTraits.h"
+
+namespace itk
+{
+  
+/** \class AdditiveGaussianNoiseImageFilter
+ *
+ * \brief Alter an image with additive gaussian white noise.
+ *
+ * \author Gaetan Lehmann
+ *
+ * \ingroup IntensityImageFilters  Multithreaded
+ * \sa InPlaceImageFilter
+ */
+template <class TInputImage, class TOutputImage=TInputImage>
+class ITK_EXPORT AdditiveGaussianNoiseImageFilter :
+      public
+InPlaceImageFilter<TInputImage,TOutputImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef AdditiveGaussianNoiseImageFilter                               Self;
+  typedef InPlaceImageFilter<
+    TInputImage,TOutputImage   >                             Superclass;
+  typedef SmartPointer<Self>                                 Pointer;
+  typedef SmartPointer<const Self>                           ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(AdditiveGaussianNoiseImageFilter, InPlaceImageFilter);
+
+  /** Superclass typedefs. */
+  typedef typename Superclass::OutputImageType       OutputImageType;
+  typedef typename Superclass::OutputImagePointer    OutputImagePointer;
+  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
+  typedef typename Superclass::OutputImagePixelType  OutputImagePixelType;
+
+  /** Some convenient typedefs. */
+  typedef TInputImage                             InputImageType;
+  typedef typename InputImageType::Pointer        InputImagePointer;
+  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
+  typedef typename InputImageType::RegionType     InputImageRegionType; 
+  typedef typename InputImageType::PixelType      InputImagePixelType; 
+  
+  itkGetConstMacro(Mean, double);
+  itkSetMacro(Mean, double);
+  
+  itkGetConstMacro(StandardDeviation, double);
+  itkSetMacro(StandardDeviation, double);
+  
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro(InputConvertibleToOutputCheck,
+                   (Concept::Convertible<typename TInputImage::PixelType,
+                    typename TOutputImage::PixelType>));
+  // The following concept check doesn't seem to work with vector immages
+  //itkConceptMacro(Input1Input2OutputDivisionOperatorsCheck,
+  //                (Concept::DivisionOperators<typename TInputImage::PixelType,
+  //                 double,
+  //                 typename TOutputImage::PixelType>));
+  /** End concept checking */
+#endif
+
+protected:
+  AdditiveGaussianNoiseImageFilter();
+  virtual ~AdditiveGaussianNoiseImageFilter() {};
+   
+  void PrintSelf(std::ostream &os, Indent indent) const;
+  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
+                            int threadId );
+
+private:
+  AdditiveGaussianNoiseImageFilter(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+  
+  double m_Mean;
+  double m_StandardDeviation;
+
+};
+
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkAdditiveGaussianNoiseImageFilter.txx"
+#endif
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.h
@@ -106,7 +106,7 @@ private:
 } // end namespace itk
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkAdditiveGaussianNoiseImageFilter.txx"
+#include "itkAdditiveGaussianNoiseImageFilter.hxx"
 #endif
 
 #endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.hxx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.hxx
@@ -29,6 +29,7 @@ template <class TInputImage, class TOutputImage>
 AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
 ::AdditiveGaussianNoiseImageFilter()
 {
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   m_Mean = 0.0;
   m_StandardDeviation = 1.0;
 }
@@ -40,8 +41,11 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
 ::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
                         int threadId)
 {
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   InputImageConstPointer  inputPtr = this->GetInput();
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   OutputImagePointer outputPtr = this->GetOutput(0);
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   
   // create a random generator per thread
   typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
@@ -51,8 +55,10 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
   // and output images to be different dimensions
   InputImageRegionType inputRegionForThread;
   this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
 
   // Define the iterators
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   ImageRegionConstIterator<TInputImage>  inputIt(inputPtr, inputRegionForThread);
   ImageRegionIterator<TOutputImage> outputIt(outputPtr, outputRegionForThread);
 
@@ -61,6 +67,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
   inputIt.GoToBegin();
   outputIt.GoToBegin();
 
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   while( !inputIt.IsAtEnd() ) 
     {
     double out = inputIt.Get() + m_Mean + m_StandardDeviation * randn->GetVariate();
@@ -71,6 +78,7 @@ AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
     ++outputIt;
     progress.CompletedPixel();  // potential exception thrown here
     }
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
 }
 
 template <class TInputImage, class TOutputImage>

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.txx
@@ -1,0 +1,91 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: $
+  Language:  C++
+  Date:      $Date: $
+  Version:   $Revision: $
+  Author:    Gavin Baker <gavinb@cs.mu.oz.au>
+
+  Copyright (c) 2004 Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#include "itkAdditiveGaussianNoiseImageFilter.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkProgressReporter.h"
+#include "itkNormalVariateGenerator.h"
+
+namespace itk
+{
+
+template <class TInputImage, class TOutputImage>
+AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
+::AdditiveGaussianNoiseImageFilter()
+{
+  m_Mean = 0.0;
+  m_StandardDeviation = 1.0;
+}
+
+
+template <class TInputImage, class TOutputImage>
+void
+AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
+::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
+                        int threadId)
+{
+  InputImageConstPointer  inputPtr = this->GetInput();
+  OutputImagePointer outputPtr = this->GetOutput(0);
+  
+  // create a random generator per thread
+  typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
+  
+  // Define the portion of the input to walk for this thread, using
+  // the CallCopyOutputRegionToInputRegion method allows for the input
+  // and output images to be different dimensions
+  InputImageRegionType inputRegionForThread;
+  this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+
+  // Define the iterators
+  ImageRegionConstIterator<TInputImage>  inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator<TOutputImage> outputIt(outputPtr, outputRegionForThread);
+
+  ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());
+
+  inputIt.GoToBegin();
+  outputIt.GoToBegin();
+
+  while( !inputIt.IsAtEnd() ) 
+    {
+    double out = inputIt.Get() + m_Mean + m_StandardDeviation * randn->GetVariate();
+    out = std::min( (double)NumericTraits<OutputImagePixelType>::max(), out );
+    out = std::max( (double)NumericTraits<OutputImagePixelType>::NonpositiveMin(), out );
+    outputIt.Set( (OutputImagePixelType) out  );
+    ++inputIt;
+    ++outputIt;
+    progress.CompletedPixel();  // potential exception thrown here
+    }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>
+::PrintSelf(std::ostream& os,
+            Indent indent) const
+{
+    Superclass::PrintSelf(os, indent);
+    os << indent << "Mean: " 
+       << static_cast<typename NumericTraits<double>::PrintType>(m_Mean)
+       << std::endl;
+    os << indent << "StandardDeviation: " 
+       << static_cast<typename NumericTraits<double>::PrintType>(m_StandardDeviation)
+       << std::endl;
+}
+
+} /* namespace itk */

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkPeakSignalToNoiseRatioCalculator.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkPeakSignalToNoiseRatioCalculator.h
@@ -1,0 +1,108 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkPeakSignalToNoiseRatioCalculator.h,v $
+  Language:  C++
+  Date:      $Date: 2004/04/25 23:59:26 $
+  Version:   $Revision: 1.37 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef __itkPeakSignalToNoiseRatioCalculator_h
+#define __itkPeakSignalToNoiseRatioCalculator_h
+
+#include "itkMacro.h"
+#include "itkImage.h"
+
+namespace itk
+{
+
+/** \class PeakSignalToNoiseRatioCalculator
+ * \brief Compute the PSNR of a noisy image
+ *
+ * \ingroup Operators
+ */
+template < class TInputImage >
+class ITK_EXPORT PeakSignalToNoiseRatioCalculator : public Object
+{
+public:
+  /** Standard class typedefs. */
+  typedef PeakSignalToNoiseRatioCalculator Self;
+  typedef Object                             Superclass;
+  typedef SmartPointer<Self>                 Pointer;
+  typedef SmartPointer<const Self>           ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(PeakSignalToNoiseRatioCalculator, Object);
+
+  /** Extract the dimension of the image. */
+  itkStaticConstMacro(ImageDimension, unsigned int,
+                      TInputImage::ImageDimension);
+
+  /** Standard image type within this class. */
+  typedef TInputImage    InputImageType;
+
+  /** Standard image type pointer within this class. */
+  typedef typename InputImageType::Pointer         InputImagePointer;
+  typedef typename InputImageType::ConstPointer    InputImageConstPointer;
+  typedef typename InputImageType::PixelType       InputPixelType;
+
+  /** Set the input image. */
+  virtual void SetImage( const InputImageType * image )
+    {
+    if ( m_Image != image )
+      {
+      m_Image = image;
+      this->Modified();
+      m_Valid = false;
+      }
+    }
+
+  virtual void SetNoisyImage( const InputImageType * image )
+    {
+    if ( m_NoisyImage != image )
+      {
+      m_NoisyImage = image;
+      this->Modified();
+      m_Valid = false;
+      }
+    }
+
+  void Compute( void );
+  
+  const double & GetOutput() const;
+
+protected:
+  PeakSignalToNoiseRatioCalculator();
+  virtual ~PeakSignalToNoiseRatioCalculator() {};
+  void PrintSelf(std::ostream& os, Indent indent) const;
+
+private:
+  PeakSignalToNoiseRatioCalculator(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+
+  bool           m_Valid;                      // Have moments been computed yet?
+  double         m_Output;
+
+  InputImageConstPointer    m_Image;
+  InputImageConstPointer    m_NoisyImage;
+
+};  // class PeakSignalToNoiseRatioCalculator
+
+} // end namespace itk
+
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkPeakSignalToNoiseRatioCalculator.txx"
+#endif
+
+#endif /* __itkPeakSignalToNoiseRatioCalculator_h */

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkPeakSignalToNoiseRatioCalculator.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkPeakSignalToNoiseRatioCalculator.txx
@@ -1,0 +1,105 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkPeakSignalToNoiseRatioCalculator.txx,v $
+  Language:  C++
+  Date:      $Date: 2005/08/10 16:32:57 $
+  Version:   $Revision: 1.52 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef __itkPeakSignalToNoiseRatioCalculator_txx
+#define __itkPeakSignalToNoiseRatioCalculator_txx
+#include "itkPeakSignalToNoiseRatioCalculator.h"
+
+#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkImageRegionConstIterator.h"
+
+namespace itk
+{ 
+
+
+template < class TInputImage>
+PeakSignalToNoiseRatioCalculator<TInputImage>
+::PeakSignalToNoiseRatioCalculator(void) 
+{
+  m_Valid = false;
+  m_Image = NULL;
+  m_NoisyImage = NULL;
+  m_Output = NumericTraits< InputPixelType >::Zero;
+}
+
+
+template < class TInputImage >
+void
+PeakSignalToNoiseRatioCalculator<TInputImage>
+::PrintSelf( std::ostream& os, Indent indent ) const
+{
+  Superclass::PrintSelf(os,indent);
+  os << indent << "Image: " << m_Image.GetPointer() << std::endl;
+  os << indent << "NoisyImage: " << m_NoisyImage.GetPointer() << std::endl;
+  os << indent << "Valid: " << m_Valid << std::endl;
+  os << indent << "Output: " << m_Output << std::endl;
+}
+
+
+template < class TInputImage >
+void
+PeakSignalToNoiseRatioCalculator<TInputImage>
+::Compute()
+{
+
+  typedef typename InputImageType::IndexType IndexType;
+
+  if( !m_Image || !m_NoisyImage ) 
+    {
+    return;
+    }
+
+  ImageRegionConstIteratorWithIndex< InputImageType > iIt( m_Image,
+                                                     m_Image->GetRequestedRegion() ); 
+  iIt.GoToBegin();
+  ImageRegionConstIteratorWithIndex< InputImageType > nIt( m_NoisyImage,
+                                                     m_NoisyImage->GetRequestedRegion() ); 
+  nIt.GoToBegin();
+
+  // init the values
+  double mse = 0;
+  InputPixelType max = NumericTraits<InputPixelType>::NonpositiveMin();
+  
+  while( !iIt.IsAtEnd() )
+    {
+    mse += pow( (double)nIt.Get() - (double)iIt.Get(), 2 );
+    max = std::max( iIt.Get(), max );
+    ++iIt;
+    ++nIt;
+    }
+  mse /= m_Image->GetRequestedRegion().GetNumberOfPixels();
+  
+  m_Output = 10 * vcl_log10( max * max / mse );
+  m_Valid = true;
+
+}
+
+
+template < class TInputImage >
+const double &
+PeakSignalToNoiseRatioCalculator<TInputImage>
+::GetOutput() const
+{
+  if (!m_Valid)
+    {
+    itkExceptionMacro( << "GetOutput() invoked, but the output have not been computed. Call Compute() first.");
+    }
+  return m_Output;
+}
+
+} // end namespace itk
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSaltAndPepperNoiseImageFilter.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSaltAndPepperNoiseImageFilter.h
@@ -1,0 +1,111 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkSaltAndPepperNoiseImageFilter.h,v $
+  Language:  C++
+  Date:      $Date: 2009-02-24 19:03:15 $
+  Version:   $Revision: 1.4 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#ifndef __itkSaltAndPepperNoiseImageFilter_h
+#define __itkSaltAndPepperNoiseImageFilter_h
+
+#include "itkInPlaceImageFilter.h"
+#include "itkNumericTraits.h"
+
+namespace itk
+{
+  
+/** \class SaltAndPepperNoiseImageFilter
+ *
+ * \brief Alter an image with fixed value impulse noise, often called salt and pepper noise.
+ *
+ * Pixel alteration occurs at a user defined probability.
+ * Salt and pepper pixel are equally distributed.
+ *
+ * \author Gaetan Lehmann
+ *
+ * \ingroup IntensityImageFilters  Multithreaded
+ * \sa InPlaceImageFilter
+ */
+template <class TInputImage, class TOutputImage=TInputImage>
+class ITK_EXPORT SaltAndPepperNoiseImageFilter :
+      public
+InPlaceImageFilter<TInputImage,TOutputImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef SaltAndPepperNoiseImageFilter                               Self;
+  typedef InPlaceImageFilter<
+    TInputImage,TOutputImage   >                             Superclass;
+  typedef SmartPointer<Self>                                 Pointer;
+  typedef SmartPointer<const Self>                           ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(SaltAndPepperNoiseImageFilter, InPlaceImageFilter);
+
+  /** Superclass typedefs. */
+  typedef typename Superclass::OutputImageType       OutputImageType;
+  typedef typename Superclass::OutputImagePointer    OutputImagePointer;
+  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
+  typedef typename Superclass::OutputImagePixelType  OutputImagePixelType;
+
+  /** Some convenient typedefs. */
+  typedef TInputImage                             InputImageType;
+  typedef typename InputImageType::Pointer        InputImagePointer;
+  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
+  typedef typename InputImageType::RegionType     InputImageRegionType; 
+  typedef typename InputImageType::PixelType      InputImagePixelType; 
+  
+  itkGetConstMacro(Probability, double);
+  itkSetMacro(Probability, double);
+  
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro(InputConvertibleToOutputCheck,
+                   (Concept::Convertible<typename TInputImage::PixelType,
+                    typename TOutputImage::PixelType>));
+  // The following concept check doesn't seem to work with vector immages
+  //itkConceptMacro(Input1Input2OutputDivisionOperatorsCheck,
+  //                (Concept::DivisionOperators<typename TInputImage::PixelType,
+  //                 double,
+  //                 typename TOutputImage::PixelType>));
+  /** End concept checking */
+#endif
+
+protected:
+  SaltAndPepperNoiseImageFilter();
+  virtual ~SaltAndPepperNoiseImageFilter() {};
+   
+  void PrintSelf(std::ostream &os, Indent indent) const;
+  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
+                            int threadId );
+
+private:
+  SaltAndPepperNoiseImageFilter(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+  
+  double m_Probability;
+
+};
+
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkSaltAndPepperNoiseImageFilter.txx"
+#endif
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSaltAndPepperNoiseImageFilter.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSaltAndPepperNoiseImageFilter.txx
@@ -1,0 +1,103 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: $
+  Language:  C++
+  Date:      $Date: $
+  Version:   $Revision: $
+  Author:    Gavin Baker <gavinb@cs.mu.oz.au>
+
+  Copyright (c) 2004 Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#include "itkSaltAndPepperNoiseImageFilter.h"
+#include "itkThreadSafeMersenneTwisterRandomVariateGenerator.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkProgressReporter.h"
+
+namespace itk
+{
+
+template <class TInputImage, class TOutputImage>
+SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>
+::SaltAndPepperNoiseImageFilter()
+{
+  m_Probability = 0.01;
+}
+
+
+template <class TInputImage, class TOutputImage>
+void
+SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>
+::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
+                        int threadId)
+{
+  InputImageConstPointer  inputPtr = this->GetInput();
+  OutputImagePointer outputPtr = this->GetOutput(0);
+  
+  // create a random generator per thread
+  typename Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::Pointer rand = 
+      Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::New();
+  rand->Initialize();
+  
+  // Define the portion of the input to walk for this thread, using
+  // the CallCopyOutputRegionToInputRegion method allows for the input
+  // and output images to be different dimensions
+  InputImageRegionType inputRegionForThread;
+  this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+
+  // Define the iterators
+  ImageRegionConstIterator<TInputImage>  inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator<TOutputImage> outputIt(outputPtr, outputRegionForThread);
+
+  ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());
+
+  inputIt.GoToBegin();
+  outputIt.GoToBegin();
+
+  while( !inputIt.IsAtEnd() ) 
+    {
+    if( rand->GetVariate() < m_Probability )
+      {
+      if( rand->GetVariate() < 0.5 )
+        {
+        // salt
+        outputIt.Set( NumericTraits<OutputImagePixelType>::max() );
+        }
+      else
+        {
+        // pepper
+        outputIt.Set( NumericTraits<OutputImagePixelType>::NonpositiveMin() );
+        }
+      }
+    else
+      {
+      // keep the data unchanged
+      outputIt.Set( (OutputImagePixelType) inputIt.Get() );
+      }
+    ++inputIt;
+    ++outputIt;
+    progress.CompletedPixel();  // potential exception thrown here
+    }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+SaltAndPepperNoiseImageFilter<TInputImage, TOutputImage>
+::PrintSelf(std::ostream& os,
+            Indent indent) const
+{
+    Superclass::PrintSelf(os, indent);
+    os << indent << "Probability: " 
+       << static_cast<typename NumericTraits<double>::PrintType>(this->GetProbability())
+       << std::endl;
+}
+
+} /* namespace itk */

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkShotNoiseImageFilter.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkShotNoiseImageFilter.h
@@ -1,0 +1,110 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkShotNoiseImageFilter.h,v $
+  Language:  C++
+  Date:      $Date: 2009-02-24 19:03:15 $
+  Version:   $Revision: 1.4 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#ifndef __itkShotNoiseImageFilter_h
+#define __itkShotNoiseImageFilter_h
+
+#include "itkInPlaceImageFilter.h"
+#include "itkNumericTraits.h"
+
+namespace itk
+{
+  
+/** \class ShotNoiseImageFilter
+ *
+ * \brief Alter an image with shot noise.
+ *
+ * The shot noise follows a Poisson distribution.
+ *
+ * \author Gaetan Lehmann
+ *
+ * \ingroup IntensityImageFilters  Multithreaded
+ * \sa InPlaceImageFilter
+ */
+template <class TInputImage, class TOutputImage=TInputImage>
+class ITK_EXPORT ShotNoiseImageFilter :
+      public
+InPlaceImageFilter<TInputImage,TOutputImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef ShotNoiseImageFilter                               Self;
+  typedef InPlaceImageFilter<
+    TInputImage,TOutputImage   >                             Superclass;
+  typedef SmartPointer<Self>                                 Pointer;
+  typedef SmartPointer<const Self>                           ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ShotNoiseImageFilter, InPlaceImageFilter);
+
+  /** Superclass typedefs. */
+  typedef typename Superclass::OutputImageType       OutputImageType;
+  typedef typename Superclass::OutputImagePointer    OutputImagePointer;
+  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
+  typedef typename Superclass::OutputImagePixelType  OutputImagePixelType;
+
+  /** Some convenient typedefs. */
+  typedef TInputImage                             InputImageType;
+  typedef typename InputImageType::Pointer        InputImagePointer;
+  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
+  typedef typename InputImageType::RegionType     InputImageRegionType; 
+  typedef typename InputImageType::PixelType      InputImagePixelType; 
+  
+  itkGetConstMacro(Scale, double);
+  itkSetMacro(Scale, double);
+  
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro(InputConvertibleToOutputCheck,
+                   (Concept::Convertible<typename TInputImage::PixelType,
+                    typename TOutputImage::PixelType>));
+  // The following concept check doesn't seem to work with vector immages
+  //itkConceptMacro(Input1Input2OutputDivisionOperatorsCheck,
+  //                (Concept::DivisionOperators<typename TInputImage::PixelType,
+  //                 double,
+  //                 typename TOutputImage::PixelType>));
+  /** End concept checking */
+#endif
+
+protected:
+  ShotNoiseImageFilter();
+  virtual ~ShotNoiseImageFilter() {};
+   
+  void PrintSelf(std::ostream &os, Indent indent) const;
+  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
+                            int threadId );
+
+private:
+  ShotNoiseImageFilter(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+  
+  double m_Scale;
+
+};
+
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkShotNoiseImageFilter.txx"
+#endif
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkShotNoiseImageFilter.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkShotNoiseImageFilter.txx
@@ -1,0 +1,107 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: $
+  Language:  C++
+  Date:      $Date: $
+  Version:   $Revision: $
+  Author:    Gavin Baker <gavinb@cs.mu.oz.au>
+
+  Copyright (c) 2004 Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#include "itkShotNoiseImageFilter.h"
+#include "itkThreadSafeMersenneTwisterRandomVariateGenerator.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkProgressReporter.h"
+#include "itkNormalVariateGenerator.h"
+
+namespace itk
+{
+
+template <class TInputImage, class TOutputImage>
+ShotNoiseImageFilter<TInputImage, TOutputImage>
+::ShotNoiseImageFilter()
+{
+  m_Scale = 1.0;
+}
+
+
+template <class TInputImage, class TOutputImage>
+void
+ShotNoiseImageFilter<TInputImage, TOutputImage>
+::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
+                        int threadId)
+{
+  InputImageConstPointer  inputPtr = this->GetInput();
+  OutputImagePointer outputPtr = this->GetOutput(0);
+  
+  // create a random generator per thread
+  typename Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::Pointer rand = 
+      Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::New();
+  rand->Initialize();
+  typename Statistics::NormalVariateGenerator::Pointer randn = Statistics::NormalVariateGenerator::New();
+  
+  // Define the portion of the input to walk for this thread, using
+  // the CallCopyOutputRegionToInputRegion method allows for the input
+  // and output images to be different dimensions
+  InputImageRegionType inputRegionForThread;
+  this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+
+  // Define the iterators
+  ImageRegionConstIterator<TInputImage>  inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator<TOutputImage> outputIt(outputPtr, outputRegionForThread);
+
+  ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());
+
+  inputIt.GoToBegin();
+  outputIt.GoToBegin();
+
+  while( !inputIt.IsAtEnd() ) 
+    {
+    double in = m_Scale * inputIt.Get();
+    if( in < 50 )
+      {
+    double L = vcl_exp( -in );
+    long k = 0;
+      double p = 1.0;
+      do
+        {
+        k += 1;
+        p *= rand->GetVariate();
+        }
+      while( p > L );
+      // clip the output to the actual supported range
+      outputIt.Set( (OutputImagePixelType) std::min( (double)NumericTraits<OutputImagePixelType>::max(), (k-1)/m_Scale ) );
+      }
+    else
+      {
+      double out = in + vcl_sqrt( in ) * randn->GetVariate();
+      outputIt.Set( (OutputImagePixelType) std::min( (double)NumericTraits<OutputImagePixelType>::max(), out/m_Scale ) );
+      }
+    ++inputIt;
+    ++outputIt;
+    progress.CompletedPixel();  // potential exception thrown here
+    }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ShotNoiseImageFilter<TInputImage, TOutputImage>
+::PrintSelf(std::ostream& os,
+            Indent indent) const
+{
+    Superclass::PrintSelf(os, indent);
+    os << indent << "Scale: " 
+       << static_cast<typename NumericTraits<double>::PrintType>(this->GetScale())
+       << std::endl;
+}
+
+} /* namespace itk */

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.h
@@ -1,0 +1,111 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkSpeckleNoiseImageFilter.h,v $
+  Language:  C++
+  Date:      $Date: 2009-02-24 19:03:15 $
+  Version:   $Revision: 1.4 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#ifndef __itkSpeckleNoiseImageFilter_h
+#define __itkSpeckleNoiseImageFilter_h
+
+#include "itkInPlaceImageFilter.h"
+#include "itkNumericTraits.h"
+
+namespace itk
+{
+  
+/** \class SpeckleNoiseImageFilter
+ *
+ * \brief Alter an image with speckle (multiplicative) noise.
+ *
+ * The speckle noise follows a Gamma distribution of mean 1 and standard deviation
+ * provided by the user. The noise is proportional to the pixel intensity.
+ *
+ * \author Gaetan Lehmann
+ *
+ * \ingroup IntensityImageFilters  Multithreaded
+ * \sa InPlaceImageFilter
+ */
+template <class TInputImage, class TOutputImage=TInputImage>
+class ITK_EXPORT SpeckleNoiseImageFilter :
+      public
+InPlaceImageFilter<TInputImage,TOutputImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef SpeckleNoiseImageFilter                               Self;
+  typedef InPlaceImageFilter<
+    TInputImage,TOutputImage   >                             Superclass;
+  typedef SmartPointer<Self>                                 Pointer;
+  typedef SmartPointer<const Self>                           ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+  
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(SpeckleNoiseImageFilter, InPlaceImageFilter);
+
+  /** Superclass typedefs. */
+  typedef typename Superclass::OutputImageType       OutputImageType;
+  typedef typename Superclass::OutputImagePointer    OutputImagePointer;
+  typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
+  typedef typename Superclass::OutputImagePixelType  OutputImagePixelType;
+
+  /** Some convenient typedefs. */
+  typedef TInputImage                             InputImageType;
+  typedef typename InputImageType::Pointer        InputImagePointer;
+  typedef typename InputImageType::ConstPointer   InputImageConstPointer;
+  typedef typename InputImageType::RegionType     InputImageRegionType; 
+  typedef typename InputImageType::PixelType      InputImagePixelType; 
+  
+  itkGetConstMacro(StandardDeviation, double);
+  itkSetMacro(StandardDeviation, double);
+  
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro(InputConvertibleToOutputCheck,
+                   (Concept::Convertible<typename TInputImage::PixelType,
+                    typename TOutputImage::PixelType>));
+  // The following concept check doesn't seem to work with vector immages
+  //itkConceptMacro(Input1Input2OutputDivisionOperatorsCheck,
+  //                (Concept::DivisionOperators<typename TInputImage::PixelType,
+  //                 double,
+  //                 typename TOutputImage::PixelType>));
+  /** End concept checking */
+#endif
+
+protected:
+  SpeckleNoiseImageFilter();
+  virtual ~SpeckleNoiseImageFilter() {};
+   
+  void PrintSelf(std::ostream &os, Indent indent) const;
+  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
+                            int threadId );
+
+private:
+  SpeckleNoiseImageFilter(const Self&); //purposely not implemented
+  void operator=(const Self&); //purposely not implemented
+  
+  double m_StandardDeviation;
+
+};
+
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkSpeckleNoiseImageFilter.txx"
+#endif
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.txx
@@ -1,0 +1,126 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: $
+  Language:  C++
+  Date:      $Date: $
+  Version:   $Revision: $
+  Author:    Gavin Baker <gavinb@cs.mu.oz.au>
+
+  Copyright (c) 2004 Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#include "itkSpeckleNoiseImageFilter.h"
+#include "itkThreadSafeMersenneTwisterRandomVariateGenerator.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkProgressReporter.h"
+
+namespace itk
+{
+
+template <class TInputImage, class TOutputImage>
+SpeckleNoiseImageFilter<TInputImage, TOutputImage>
+::SpeckleNoiseImageFilter()
+{
+  m_StandardDeviation = 1.0;
+}
+
+
+template <class TInputImage, class TOutputImage>
+void
+SpeckleNoiseImageFilter<TInputImage, TOutputImage>
+::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
+                        int threadId)
+{
+  InputImageConstPointer  inputPtr = this->GetInput();
+  OutputImagePointer outputPtr = this->GetOutput(0);
+  
+  // create a random generator per thread
+  typename Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::Pointer rand = 
+      Statistics::ThreadSafeMersenneTwisterRandomVariateGenerator::New();
+  rand->Initialize();
+  
+  // Define the portion of the input to walk for this thread, using
+  // the CallCopyOutputRegionToInputRegion method allows for the input
+  // and output images to be different dimensions
+  InputImageRegionType inputRegionForThread;
+  this->CallCopyOutputRegionToInputRegion(inputRegionForThread, outputRegionForThread);
+
+  // Define the iterators
+  ImageRegionConstIterator<TInputImage>  inputIt(inputPtr, inputRegionForThread);
+  ImageRegionIterator<TOutputImage> outputIt(outputPtr, outputRegionForThread);
+
+  ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels());
+
+  inputIt.GoToBegin();
+  outputIt.GoToBegin();
+
+  // choose the value of the gamma distribution so that the mean is 1 and the variance depend
+  // on m_StandardDeviation
+  double theta = m_StandardDeviation * m_StandardDeviation;
+  double k = 1 / theta;
+  double floork = itk::Math::Floor( k );
+  double delta = k - floork;
+  double v0 = itk::Math::e / ( itk::Math::e + delta );
+
+  while( !inputIt.IsAtEnd() ) 
+    {
+    // first generate the gamma distributed random variable
+    // ref http://en.wikipedia.org/wiki/Gamma_distribution#Generating_gamma-distributed_random_variables
+    double xi;
+    double nu;
+    do
+      {
+      double v1 = 1.0 - rand->GetVariateWithOpenUpperRange(); // open *lower* range -- (0,1]
+      double v2 = 1.0 - rand->GetVariateWithOpenUpperRange();
+      double v3 = 1.0 - rand->GetVariateWithOpenUpperRange();
+      if( v1 <= v0 )
+        {
+        xi = vcl_pow( v2, 1 / delta );
+        nu = v3 * vcl_pow( xi, delta - 1.0 );
+        }
+      else
+        {
+        xi = 1.0 - vcl_log( v2 );
+        nu = v3 * vcl_exp( -xi );
+        }
+      }
+    while( nu > vcl_exp( -xi ) * vcl_pow( xi, delta - 1.0 ) );
+    double gamma = xi;
+    for( int i=0; i<floork; i++ )
+      {
+      gamma -= vcl_log( 1.0 - rand->GetVariateWithOpenUpperRange() ); 
+      }
+    gamma *= theta;
+    // ok, so now apply multiplicative noise    
+    double out = gamma * inputIt.Get();
+    // and clip the value to fit in the range (saturation)
+    out = std::min( (double)NumericTraits<OutputImagePixelType>::max(), out );
+    out = std::max( (double)NumericTraits<OutputImagePixelType>::NonpositiveMin(), out );
+    outputIt.Set( (OutputImagePixelType) out  );
+    ++inputIt;
+    ++outputIt;
+    progress.CompletedPixel();  // potential exception thrown here
+    }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+SpeckleNoiseImageFilter<TInputImage, TOutputImage>
+::PrintSelf(std::ostream& os,
+            Indent indent) const
+{
+    Superclass::PrintSelf(os, indent);
+    os << indent << "StandardDeviation: " 
+       << static_cast<typename NumericTraits<double>::PrintType>(this->GetStandardDeviation())
+       << std::endl;
+}
+
+} /* namespace itk */

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.txx
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkSpeckleNoiseImageFilter.txx
@@ -39,7 +39,9 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>
 ::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
                         int threadId)
 {
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   InputImageConstPointer  inputPtr = this->GetInput();
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   OutputImagePointer outputPtr = this->GetOutput(0);
   
   // create a random generator per thread
@@ -64,12 +66,14 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>
 
   // choose the value of the gamma distribution so that the mean is 1 and the variance depend
   // on m_StandardDeviation
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   double theta = m_StandardDeviation * m_StandardDeviation;
   double k = 1 / theta;
   double floork = itk::Math::Floor( k );
   double delta = k - floork;
   double v0 = itk::Math::e / ( itk::Math::e + delta );
 
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
   while( !inputIt.IsAtEnd() ) 
     {
     // first generate the gamma distributed random variable
@@ -109,6 +113,7 @@ SpeckleNoiseImageFilter<TInputImage, TOutputImage>
     ++outputIt;
     progress.CompletedPixel();  // potential exception thrown here
     }
+  std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
 }
 
 template <class TInputImage, class TOutputImage>

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkTestingMacros.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkTestingMacros.h
@@ -1,0 +1,69 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkTestingMacros.h,v $
+  Language:  C++
+  Date:      $Date: 2009-07-13 23:52:42 $
+  Version:   $Revision: 1.2 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef __itkTestingMacros_h
+#define __itkTestingMacros_h
+
+
+#define TRY_EXPECT_EXCEPTION( command ) \
+  try \
+    {  \
+    std::cout << "Trying " << #command << std::endl; \
+    command;  \
+    std::cerr << "Failed to catch expected exception" << std::endl;  \
+    return EXIT_FAILURE;  \
+    }  \
+  catch( itk::ExceptionObject & excp )  \
+    {  \
+    std::cout << "Caught expected exception" << std::endl;  \
+    std::cout << excp << std::endl; \
+    }  
+
+
+#define TRY_EXPECT_NO_EXCEPTION( command ) \
+  try \
+    {  \
+    std::cout << "Trying " << #command << std::endl; \
+    command;  \
+    }  \
+  catch( itk::ExceptionObject & excp )  \
+    {  \
+    std::cerr << excp << std::endl; \
+    return EXIT_FAILURE;  \
+    }  
+
+
+#define TEST_SET_GET( variable, command ) \
+  if( variable.GetPointer() != command )   \
+    {   \
+    std::cerr << "Error in " << #command << std::endl; \
+    std::cerr << "Expected " << variable.GetPointer() << std::endl; \
+    std::cerr << "but got  " << command << std::endl; \
+    return EXIT_FAILURE; \
+    }
+
+
+#define TEST_SET_GET_VALUE( variable, command ) \
+  if( variable != command )   \
+    {   \
+    std::cerr << "Error in " << #command << std::endl; \
+    std::cerr << "Expected " << variable << std::endl; \
+    std::cerr << "but got  " << command << std::endl; \
+    return EXIT_FAILURE; \
+    }
+
+
+#endif

--- a/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkThreadSafeMersenneTwisterRandomVariateGenerator.h
+++ b/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkThreadSafeMersenneTwisterRandomVariateGenerator.h
@@ -1,0 +1,584 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    $RCSfile: itkThreadSafeMersenneTwisterRandomVariateGenerator.h,v $
+  Language:  C++
+  Date:      $Date: 2009-12-14 18:34:54 $
+  Version:   $Revision: 1.10 $
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef __itkThreadSafeMersenneTwisterRandomVariateGenerator_h
+#define __itkThreadSafeMersenneTwisterRandomVariateGenerator_h
+
+#if defined(_MSC_VER)
+#pragma warning ( disable : 4146 )
+#endif
+
+#include "itkMacro.h"
+#include "itkObjectFactory.h"
+#include "itkRandomVariateGeneratorBase.h"
+#include "itkIntTypes.h"
+#include "vcl_ctime.h"
+#include "vnl/vnl_math.h"
+#include <limits.h>
+
+
+namespace itk {
+namespace Statistics {
+
+/** \class ThreadSafeMersenneTwisterRandomVariateGenerator
+ * \brief MersenneTwisterRandom random variate generator
+ *
+ * \warning This class is NOT thread-safe.
+ *
+ * This notice was included with the original implementation.
+ * The only changes made were to obfuscate the author's email addresses.
+ *
+ * MersenneTwister.h
+ * Mersenne Twister random number generator -- a C++ class MTRand
+ * Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
+ * Richard J. Wagner  v1.0  15 May 2003  rjwagner at writeme dot com
+ *
+ * The Mersenne Twister is an algorithm for generating random numbers.  It
+ * was designed with consideration of the flaws in various other generators.
+ * The period, 2^19937-1, and the order of equidistribution, 623 dimensions,
+ * are far greater.  The generator is also fast; it avoids multiplication and
+ * division, and it benefits from caches and pipelines.  For more information
+ * see the inventors' web page at http:*www.math.keio.ac.jp/~matumoto/emt.html
+
+ * Reference
+ * M. Matsumoto and T. Nishimura, "Mersenne Twister: A 623-Dimensionally
+ * Equidistributed Uniform Pseudo-Random Number Generator", ACM Transactions on
+ * Modeling and Computer Simulation, Vol. 8, No. 1, January 1998, pp 3-30.
+ *
+ * Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+ * Copyright (C) 2000 - 2003, Richard J. Wagner
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   3. The names of its contributors may not be used to endorse or promote 
+ *      products derived from this software without specific prior written 
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The original code included the following notice:
+ *
+ *     When you use this, send an email to: matumoto at math dot keio dot ac dot jp
+ *     with an appropriate reference to your work.
+ *
+ * It would be nice to CC: 
+ * rjwagner at writeme dot com and Cokus at math dot washington dot edu
+ * when you write.
+ *
+ * \ingroup Statistics
+ */
+class ITKCommon_EXPORT ThreadSafeMersenneTwisterRandomVariateGenerator : 
+    public RandomVariateGeneratorBase
+{
+public:
+  
+  /** Standard class typedefs. */
+  typedef ThreadSafeMersenneTwisterRandomVariateGenerator Self;
+  typedef RandomVariateGeneratorBase            Superclass;
+  typedef SmartPointer<Self>                    Pointer;
+  typedef SmartPointer<const Self>              ConstPointer;
+
+  typedef uint32_t IntegerType;
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ThreadSafeMersenneTwisterRandomVariateGenerator, 
+               RandomVariateGeneratorBase );
+ 
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Length of state vector */
+  itkStaticConstMacro(StateVectorLength,IntegerType,624);
+ 
+  /** Length of array for save() */
+  // itkStaticConstMacro(SAVE,IntegerType,625);
+  
+  
+  
+  // Methods to reseed
+  
+  /** initialize with a simple IntegerType */
+  void Initialize( const IntegerType oneSeed );
+  
+  /** Initialize with an array */
+  //void Initialize( IntegerType *const bigSeed, 
+  //        IntegerType const seedLength = StateVectorLength );  
+  
+  /* Initialize with vcl_clock time */ 
+  void Initialize();  
+  
+  // Methods to get various random variates ...
+  
+  /** Get a random variate in the range [0, 1] */
+  double GetVariateWithClosedRange();
+
+  /** Get a random variate in the range [0, n] */
+  double GetVariateWithClosedRange( const double& n );
+    
+  /** Get a range variate in the range [0, 1) */
+  double GetVariateWithOpenUpperRange();
+  
+  /** Get a range variate in the range [0, n) */
+  double GetVariateWithOpenUpperRange( const double& n );
+  
+  /** Get a range variate in the range (0, 1) */
+  double GetVariateWithOpenRange();
+  
+  /** Get a range variate in the range (0, n) */
+  double GetVariateWithOpenRange( const double& n );
+  
+  /** Get an integer variate in [0, 2^32-1] */
+  IntegerType GetIntegerVariate();
+  
+  /** Get an integer variate in [0, n] for n < 2^32 */
+  IntegerType GetIntegerVariate( const IntegerType& n );
+  
+  /** Access to 53-bit random numbers (capacity of IEEE double precision) 
+   * in the range [0,1) */
+  double Get53BitVariate();
+  
+  /* Access to a normal random number distribution 
+   * TODO: Compare with vnl_sample_normal */
+  double GetNormalVariate( const double& mean = 0.0, 
+      const double& variance = 1.0 );
+  
+  /* Access to a uniform random number distribution in the range [a, b)
+   * TODO: Compare with vnl_sample_uniform */
+  double GetUniformVariate( const double& a, const double& b );
+  
+  /** get a variate in the range [0, 1]
+   * Do NOT use for CRYPTOGRAPHY without securely hashing several returned
+   * values together, otherwise the generator state can be learned after
+   * reading 624 consecutive values.
+   */
+  virtual double GetVariate();
+     
+  /** Same as GetVariate() */
+  double operator()(); 
+   
+
+  // Re-seeding functions with same behavior as initializers
+  inline void SetSeed( const IntegerType oneSeed );
+  inline void SetSeed( IntegerType * bigSeed, const IntegerType seedLength = StateVectorLength );
+  inline void SetSeed();
+
+  /*
+  // Saving and loading generator state
+  void save( IntegerType* saveArray ) const;  // to array of size SAVE
+  void load( IntegerType *const loadArray );  // from such array
+  */
+
+protected:
+  inline ThreadSafeMersenneTwisterRandomVariateGenerator();
+  virtual ~ThreadSafeMersenneTwisterRandomVariateGenerator() {}; 
+  virtual void PrintSelf(std::ostream& os, Indent indent) const {
+    Superclass::PrintSelf(os, indent);
+
+    // Print state vector contents
+    os << indent << "State vector: " << state << std::endl;
+    os << indent;
+    register const IntegerType *s = state;
+    register int i = StateVectorLength;
+    for(; i--; os << *s++ << "\t" ) {}
+    os << std::endl;
+    
+    //Print next value to be gotten from state
+    os << indent << "Next value to be gotten from state: " << pNext << std::endl;
+    
+    //Number of values left before reload
+    os << indent << "Values left before next reload: " << left << std::endl;
+  }
+
+
+  // enum { M = 397 };  // period parameter
+  itkStaticConstMacro ( M, unsigned int, 397 );
+  
+  IntegerType state[StateVectorLength];   // internal state
+  IntegerType *pNext;     // next value to get from state
+  int left;          // number of values left before reload needed
+
+  /* Reload array with N new values */
+  void reload();
+  
+  IntegerType hiBit( const IntegerType& u ) const { return u & 0x80000000UL; }
+  IntegerType loBit( const IntegerType& u ) const { return u & 0x00000001UL; }
+  IntegerType loBits( const IntegerType& u ) const { return u & 0x7fffffffUL; }
+  IntegerType mixBits( const IntegerType& u, const IntegerType& v ) const
+    { 
+    return hiBit(u) | loBits(v); 
+    }
+  IntegerType twist( const IntegerType& m, const IntegerType& s0, const IntegerType& s1 ) const
+    { 
+    return m ^ (mixBits(s0,s1)>>1) ^ (-loBit(s1) & 0x9908b0dfUL); 
+    }
+  static IntegerType hash( vcl_time_t t, vcl_clock_t c );
+};  // end of class
+  
+// Declare inlined functions.... (must be declared in the header)
+// Declare then in order to keep SGI happy
+
+inline ThreadSafeMersenneTwisterRandomVariateGenerator::IntegerType 
+ThreadSafeMersenneTwisterRandomVariateGenerator::hash( vcl_time_t t, vcl_clock_t c )
+{
+  // Get a IntegerType from t and c
+  // Better than IntegerType(x) in case x is floating point in [0,1]
+  // Based on code by Lawrence Kirby: fred at genesis dot demon dot co dot uk 
+
+  IntegerType h1 = 0;
+  unsigned char *p = (unsigned char *) &t;
+  for( size_t i = 0; i < sizeof(t); ++i )
+    {
+    h1 *= UCHAR_MAX + 2U;
+    h1 += p[i];
+    }
+  IntegerType h2 = 0;
+  p = (unsigned char *) &c;
+  for( size_t j = 0; j < sizeof(c); ++j )
+    {
+    h2 *= UCHAR_MAX + 2U;
+    h2 += p[j];
+    }
+  return h1 ^ h2;
+}
+
+
+inline void 
+ThreadSafeMersenneTwisterRandomVariateGenerator::Initialize( const IntegerType seed )
+{
+  // Initialize generator state with seed
+  // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
+  // In previous versions, most significant bits (MSBs) of the seed affect
+  // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
+  register IntegerType *s = state;
+  register IntegerType *r = state;
+  register IntegerType i = 1;
+  *s++ = seed & 0xffffffffUL;
+  for( i = 1; i < ThreadSafeMersenneTwisterRandomVariateGenerator::StateVectorLength; ++i )
+    {
+    *s++ = ( 1812433253UL * ( *r ^ (*r >> 30) ) + i ) & 0xffffffffUL;
+    r++;
+    }
+}
+
+inline void 
+ThreadSafeMersenneTwisterRandomVariateGenerator::reload()
+{
+  // Generate N new values in state
+  // Made clearer and faster by Matthew Bellew 
+  // matthew dot bellew at home dot com
+  
+  // get rid of VS warning
+  register int index = static_cast< int >(
+      M-ThreadSafeMersenneTwisterRandomVariateGenerator::StateVectorLength);
+    
+  register IntegerType *p = state;
+  register int i;
+  for( i = ThreadSafeMersenneTwisterRandomVariateGenerator::StateVectorLength - M; i--; ++p )
+    {
+    *p = twist( p[M], p[0], p[1] );
+    }
+  for( i = M; --i; ++p )
+    {
+    *p = twist( p[index], p[0], p[1] );
+    }
+  *p = twist( p[index], p[0], state[0] );
+
+  left = ThreadSafeMersenneTwisterRandomVariateGenerator::StateVectorLength, pNext = state;
+}
+
+#define SVL 624
+inline void 
+ThreadSafeMersenneTwisterRandomVariateGenerator::SetSeed( 
+  IntegerType * const bigSeed, const IntegerType seedLength )
+{
+  // Seed the generator with an array of IntegerType's
+  // There are 2^19937-1 possible initial states.  This function allows
+  // all of those to be accessed by providing at least 19937 bits (with a
+  // default seed length of StateVectorLength = 624 IntegerType's).  
+  // Any bits above the lower 32
+  // in each element are discarded.
+  // Just call seed() if you want to get array from /dev/urandom
+  Initialize(19650218UL);
+  register IntegerType i = 1;
+  register IntegerType j = 0;
+  register int k;
+  if ( StateVectorLength > seedLength )
+    {
+    k = StateVectorLength;
+    }
+  else
+    {
+    k = seedLength;
+    }
+  for(; k; --k )
+    {
+    state[i] =
+      state[i] ^ ( (state[i-1] ^ (state[i-1] >> 30)) * 1664525UL );
+    state[i] += ( bigSeed[j] & 0xffffffffUL ) + j;
+    state[i] &= 0xffffffffUL;
+    ++i;  ++j;
+    if( i >= StateVectorLength ) { state[0] = state[StateVectorLength-1];  i = 1; }
+    if( j >= seedLength ) j = 0;
+    }
+  for( k = StateVectorLength - 1; k; --k )
+    {
+    state[i] =
+      state[i] ^ ( (state[i-1] ^ (state[i-1] >> 30)) * 1566083941UL );
+    state[i] -= i;
+    state[i] &= 0xffffffffUL;
+    ++i;
+    if( i >= SVL ) 
+      { 
+      state[0] = state[StateVectorLength-1];  i = 1; 
+      }
+    }
+  state[0] = 0x80000000UL;  // MSB is 1, assuring non-zero initial array
+  reload();
+}
+
+
+inline void
+ThreadSafeMersenneTwisterRandomVariateGenerator::Initialize()
+{ 
+  SetSeed(); 
+}
+
+
+inline void 
+ThreadSafeMersenneTwisterRandomVariateGenerator::SetSeed( const IntegerType oneSeed )
+{
+  // Seed the generator with a simple IntegerType
+  Initialize(oneSeed);
+  reload();
+}
+
+
+inline void 
+ThreadSafeMersenneTwisterRandomVariateGenerator::SetSeed()
+{
+  // use time() and clock() to generate a unlikely-to-repeat seed.
+  SetSeed( hash( vcl_time(0), vcl_clock() ) );
+}
+
+/** Get an integer variate in [0, 2^32-1] */
+inline ThreadSafeMersenneTwisterRandomVariateGenerator::IntegerType 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetIntegerVariate()
+{
+  if( left == 0 ) reload();
+  --left;
+
+  register IntegerType s1;
+  s1 = *pNext++;
+  s1 ^= (s1 >> 11);
+  s1 ^= (s1 <<  7) & 0x9d2c5680UL;
+  s1 ^= (s1 << 15) & 0xefc60000UL;
+  return ( s1 ^ (s1 >> 18) );
+}
+
+
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange()
+{ 
+  return double(GetIntegerVariate()) * (1.0/4294967295.0); 
+}
+
+/** Get a random variate in the range [0, n] */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithClosedRange( 
+                                                    const double& n )
+{ 
+  return GetVariateWithClosedRange() * n; 
+}
+
+/** Get a range variate in the range [0, 1) */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange()
+{ 
+  return double(GetIntegerVariate()) * (1.0/4294967296.0); 
+}
+
+/** Get a range variate in the range [0, n) */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithOpenUpperRange( 
+  const double& n )
+{ 
+  return GetVariateWithOpenUpperRange() * n; 
+}
+  
+/** Get a range variate in the range (0, 1) */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange()
+{
+  return ( double(GetIntegerVariate()) + 0.5 ) * (1.0/4294967296.0); 
+}
+
+
+/** Get a range variate in the range (0, n) */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariateWithOpenRange( 
+  const double& n )
+{ 
+  return GetVariateWithOpenRange() * n; 
+}
+
+
+inline ThreadSafeMersenneTwisterRandomVariateGenerator::IntegerType 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetIntegerVariate( 
+                                        const IntegerType& n )
+{
+  // Find which bits are used in n
+  // Optimized by Magnus Jonsson magnus at smartelectronix dot com
+  IntegerType used = n;
+  used |= used >> 1;
+  used |= used >> 2;
+  used |= used >> 4;
+  used |= used >> 8;
+  used |= used >> 16;
+
+  // Draw numbers until one is found in [0,n]
+  IntegerType i;
+  do
+    {
+    i = GetIntegerVariate() & used;  // toss unused bits to shorten search
+    }
+  while( i > n );
+  
+  return i;
+}
+
+
+/** Access to 53-bit random numbers (capacity of IEEE double precision) 
+ * in the range [0,1) */
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::Get53BitVariate()  
+{
+  IntegerType a = GetIntegerVariate() >> 5, b = GetIntegerVariate() >> 6;
+  return ( a * 67108864.0 + b ) * (1.0/9007199254740992.0);  // by Isaku Wada
+}
+  
+
+/* Access to a normal random number distribution */
+// TODO: Compare with vnl_sample_normal
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetNormalVariate( 
+  const double& mean, const double& variance )
+{
+  // Return a real number from a normal (Gaussian) distribution with given
+  // mean and variance by Box-Muller method
+  double r = vcl_sqrt( -2.0 * vcl_log( 1.0-GetVariateWithOpenRange()) * variance);
+  double phi = 2.0 * vnl_math::pi
+                          * GetVariateWithOpenUpperRange();
+  return mean + r * vcl_cos(phi);
+}
+
+
+/* Access to a uniform random number distribution */
+// TODO: Compare with vnl_sample_uniform
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetUniformVariate( 
+                            const double& a, const double& b )
+{
+  double u = GetVariateWithOpenUpperRange();
+  return ((1.0 -u) * a + u * b); 
+}
+
+
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::GetVariate() 
+{
+  return GetVariateWithClosedRange();
+}
+
+
+inline double 
+ThreadSafeMersenneTwisterRandomVariateGenerator::operator()()
+{ 
+  return GetVariate(); 
+}  
+ 
+
+inline 
+ThreadSafeMersenneTwisterRandomVariateGenerator::ThreadSafeMersenneTwisterRandomVariateGenerator()
+{
+  SetSeed ( 121212 );
+}
+  
+
+/* Change log from MTRand.h */
+// Change log:
+//
+// v0.1 - First release on 15 May 2000
+//      - Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
+//      - Translated from C to C++
+//      - Made completely ANSI compliant
+//      - Designed convenient interface for initialization, seeding, and
+//        obtaining numbers in default or user-defined ranges
+//      - Added automatic seeding from /dev/urandom or time() and clock()
+//      - Provided functions for saving and loading generator state
+//
+// v0.2 - Fixed bug which reloaded generator one step too late
+//
+// v0.3 - Switched to clearer, faster reload() code from Matthew Bellew
+//
+// v0.4 - Removed trailing newline in saved generator format to be consistent
+//        with output format of built-in types
+//
+// v0.5 - Improved portability by replacing static const int's with enum's and
+//        clarifying return values in seed(); suggested by Eric Heimburg
+//      - Removed MAXINT constant; use 0xffffffffUL instead
+//
+// v0.6 - Eliminated seed overflow when uint32 is larger than 32 bits
+//      - Changed integer [0,n] generator to give better uniformity
+//
+// v0.7 - Fixed operator precedence ambiguity in reload()
+//      - Added access for real numbers in (0,1) and (0,n)
+//
+// v0.8 - Included time.h header to properly support time_t and clock_t
+//
+// v1.0 - Revised seeding to match 26 Jan 2002 update of Nishimura and Matsumoto
+//      - Allowed for seeding with arrays of any length
+//      - Added access for real numbers in [0,1) with 53-bit resolution
+//      - Added access for real numbers from normal (Gaussian) distributions
+//      - Increased overall speed by optimizing twist()
+//      - Doubled speed of integer [0,n] generation
+//      - Fixed out-of-range number generation on 64-bit machines
+//      - Improved portability by substituting literal constants for long enum's
+//      - Changed license from GNU LGPL to BSD
+
+} // end of namespace Statistics
+} // end of namespace itk
+
+#endif


### PR DESCRIPTION
Hello all, 

Yes I am back, and started to bug you. Sorry and thanks. 

If any of you remember this, I fixed the stupid error I created in the xml file. This time, it looks like the 'New' command of the 'itkAdditiveGaussianNoiseImageFilter.h' having an issue. 

The code only gives a warning (no error!) as following:

/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.h: In instantiation of ‘itk::AdditiveGaussianNoiseImageFilter<itk::Image<float, 3u>, itk::Image<float, 3u> >’:
/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx:38:   instantiated from here
/ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/ITKv4/Modules/Core/Common/include/itkImageSource.hxx:288: warning: ‘void itk::ImageSource<TOutputImage>::ThreadedGenerateData(const typename TOutputImage::RegionType&, itk::ThreadIdType) [with TOutputImage = itk::Image<float, 3u>]’ was hidden
/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.hxx:42: warning:   by ‘void itk::AdditiveGaussianNoiseImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(const typename itk::InPlaceImageFilter<TInputImage, TOutputImage>::OutputImageRegionType&, int) [with TInputImage = itk::Image<float, 3u>, TOutputImage = itk::Image<float, 3u>]’
Linking CXX shared library /ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/lib/libNoiseGeneratorLib.dylib
ld: warning: directory not found for option '-L/IPLlinux/ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/OpenCV-install/share/OpenCV/3rdparty/lib'
[ 99%] Built target NoiseGeneratorLib
Linking CXX executable /ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/lib/NoiseGenerator
ld: warning: directory not found for option '-L/IPLlinux/ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/OpenCV-install/share/OpenCV/3rdparty/lib'
[100%] Built target NoiseGenerator
[ 78%] No install step for 'BRAINSTools'
[ 78%] Completed 'BRAINSTools'
[100%] Built target BRAINSTools

And then if I try to run the binary, I get the following error::

/ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/lib/NoiseGenerator --inputVolume /ipldev/scratch/eunyokim/src/BRAINS20111028/build-Darwin-Debug/ReferenceAtlas-build/Atlas/Atlas_20120104/template_t1.nii.gz --outputVolume ~/Desktop/outputTest.nii.gz --inputGaissianMean 0 --inputGaussianStandardDeviation 1
10::/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
12::/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/NoiseGenerator.cxx
32::/ipldev/scratch/eunyokim/src/BRAINS20111028/BRAINSStandAlone/BRAINSCut/BRAINSFeatureCreators/NoiseGenerator/itkAdditiveGaussianNoiseImageFilter.hxx

It fails at the 'New' part. Can any one please help me? The warning message says something has been 'hidden' and I am guessint that part causes the issue. 

Thanks. 

Regina
