### PR TITLE
BUG Fixed: BCD failure to estimate MSP plane

### DIFF
--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetector2.h
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetector2.h
@@ -154,6 +154,7 @@ public:
 
   /** Set the original input image before the Hough eye detector */
   itkSetObjectMacro(OriginalInputImage, SImageType);
+  itkGetObjectMacro(OriginalInputImage, SImageType);
 
   // Get Basic Outputs
 

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
@@ -103,6 +103,9 @@ bool BRAINSConstellationDetectorPrimary::Compute( void )
     }
     std::cout << "Processing: " << this->m_inputVolume << std::endl;
     
+    
+    //std::cout << "original input file : " << reader->GetOutput() << std::endl;  //Added by Ali
+    
     // ------------------------------------
     // Find center of head mass
     std::cout << "\nFinding center of head mass..." << std::endl;

--- a/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationModeler.cxx
@@ -270,7 +270,8 @@ int main(int argc, char *argv[])
     // transforms image to MSP aligned voxel lattice
     RigidTransformType::Pointer Tmsp = RigidTransformType::New();
     SImageType::Pointer         volumeMSP;
-    ComputeMSP(image, Tmsp, volumeMSP, centerOfHeadMass, mspQualityLevel);
+    double c_c = 0;
+    ComputeMSP(image, Tmsp, volumeMSP, centerOfHeadMass, mspQualityLevel, c_c);
 
     if( globalImagedebugLevel > 2 )
       {

--- a/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
+++ b/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
@@ -56,6 +56,7 @@ public:
     this->m_params = params;
     const double HARange = 25.0;
     const double BARange = 15.0;
+
     // rough search in neighborhood.
     const double one_degree = 1.0F * vnl_math::pi / 180.0F;
     const double HAStepSize = HARange * one_degree * .1;
@@ -214,7 +215,7 @@ public:
   {
     return m_Iterations;
   }
-
+    
   /* -- */
   SImageType::PixelType GetBackgroundValue(void) const
   {
@@ -379,7 +380,12 @@ public:
              GetInterpolatorFromString<SImageType>("Linear"),
              GetTransformToMSP().GetPointer() );
   }
-
+    
+  double GetCC(void) const
+  {
+   return m_cc;
+  }
+/*
   void Update(void)
   {
     this->m_Optimizer.minimize(this->m_params);
@@ -387,7 +393,16 @@ public:
               << this->m_params[2] << " cc= " << this->f(this->m_params) << " iters= " << this->GetIterations()
               << std::endl;
   }
-
+*/
+  void Update(void)
+  {
+    this->m_Optimizer.minimize(this->m_params);
+    m_cc = this->f(this->m_params);
+    std::cout << this->m_params[0] * 180.0 / vnl_math::pi << " " << this->m_params[1] * 180.0 / vnl_math::pi << " "
+              << this->m_params[2] << " cc= " << m_cc << " iters= " << this->GetIterations()
+              << std::endl;
+  }
+    
 private:
 
   SImageType::Pointer SimpleResampleImage(SImageType::Pointer image, RigidTransformType::Pointer EulerAngles3DT)
@@ -435,6 +450,7 @@ private:
   int                               m_Iterations;
   OptimizerType                     m_Optimizer;
   LinearInterpolatorType::Pointer   m_imInterp;
+  double                            m_cc;
 };
 
 namespace itk

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.cxx
@@ -34,9 +34,12 @@ std::string globalResultsDir(".");       // A global variable to define where
 int globalImagedebugLevel(1000);         // A global variable to determine the
                                          // level of debugging to perform.
 
-void ComputeMSP(SImageType::Pointer image, RigidTransformType::Pointer & Tmsp,
+void ComputeMSP(SImageType::Pointer image, 
+                RigidTransformType::Pointer & Tmsp,
                 SImageType::Pointer & transformedImage,
-                const SImageType::PointType & centerOfHeadMass, const int qualityLevel)
+                const SImageType::PointType & centerOfHeadMass, 
+                const int qualityLevel,
+                double & cc)
 {
   if( qualityLevel == -1 )  // Assume image was pre-aligned outside of the
                             // program
@@ -88,6 +91,7 @@ void ComputeMSP(SImageType::Pointer image, RigidTransformType::Pointer & Tmsp,
     reflectionFunctor.SetDownSampledReferenceImage(image);
     Tmsp = reflectionFunctor.GetTransformToMSP();
     transformedImage = reflectionFunctor.GetMSPCenteredImage();
+    cc = reflectionFunctor.GetCC();
     }
 }
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationCommon.h
@@ -155,7 +155,7 @@ extern void InitializeRandomZeroOneDouble(RandomGeneratorType::IntegerType rseed
 
 extern void ComputeMSP(SImageType::Pointer image, RigidTransformType::Pointer & Tmsp,
                        SImageType::Pointer & transformedImage, const SImageType::PointType & centerOfHeadMass,
-                       const int qualityLevel);
+                       const int qualityLevel, double & cc);
 
 extern void ComputeMSP(SImageType::Pointer image, RigidTransformType::Pointer & Tmsp, const int qualityLevel);
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -271,6 +271,12 @@ void landmarksConstellationDetector::Compute( void )
         ComputeMSP( houghEyeDetector->GetOutput(), this->m_finalTmsp,
                    this->m_VolumeMSP, houghTransformedCOHM_new, this->m_mspQualityLevel, c_c );
         std::cout << "\n=============================================================" << std::endl;
+        
+        if ( c_c > -0.7 )
+        {
+            std::cout << "too large MSP estimation error at the final try!\n"
+                      << "The estimation result is probably not reliable.\n" << std::endl;
+        }
     }
     
     

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.cxx
@@ -9,6 +9,10 @@
 #include "landmarkIO.h"
 #include "itkOrthogonalize3DRotationMatrix.h"
 
+#include "itkFindCenterOfBrainFilter.h"
+#include "BRAINSHoughEyeDetector.h"
+
+
 SImageType::PointType
 landmarksConstellationDetector::FindCandidatePoints
   ( SImageType::Pointer volumeMSP,
@@ -176,9 +180,100 @@ void landmarksConstellationDetector::Compute( void )
     }
 
   // Compute the estimated MSP transform, and aligned image
+  double c_c = 0;
   ComputeMSP( this->m_VolOrig, this->m_finalTmsp,
-              this->m_VolumeMSP, this->m_CenterOfHeadMass, this->m_mspQualityLevel );
+              this->m_VolumeMSP, this->m_CenterOfHeadMass, this->m_mspQualityLevel, c_c );
 
+    // Try to compute a better estimation for MSP plane when Reflective correlation is not good enough
+    if ( c_c > -0.7 ) 
+    {
+        std::cout << "\n============================================================="
+        << "\nBad Estimation for MSP Plane. Repeat the Procedure to Find a Better Estimation..." << std::endl;
+        
+        // The current "m_CenterOfHeadMass" has been modified by the hough eye transform,
+        // So CM is computed again from the original input image
+        std::cout << "\nNeed to Find the center of head mass again..." << std::endl;
+        itk::FindCenterOfBrainFilter<SImageType>::Pointer findCenterFilter = itk::FindCenterOfBrainFilter<SImageType>::New();
+        findCenterFilter->SetInput( this->m_OriginalInput );
+        findCenterFilter->SetAxis( 2 );
+        findCenterFilter->SetOtsuPercentileThreshold( 0.01 );
+        findCenterFilter->SetClosingSize( 7 );
+        findCenterFilter->SetHeadSizeLimit( 700 );
+        findCenterFilter->SetBackgroundValue( 0 );
+        findCenterFilter->Update();
+        SImageType::PointType centerOfHeadMass = findCenterFilter->GetCenterOfBrain();
+
+        // The current "this->m_VolOrig" is the output of the hough eye detector.
+        // First, MSP is computed again based on the original input 
+        std::cout << "\nEstimating MSP Based on the original input..." << std::endl;
+        ComputeMSP( this->m_OriginalInput, this->m_finalTmsp,
+                   this->m_VolumeMSP, centerOfHeadMass, this->m_mspQualityLevel, c_c );
+        
+        // At this level, the MSP has not calculated properly by the ComputeMSP.
+        // The output of ComputeMSP is considered as a new input for the function to estimate a better reflective correlation.
+        SImageType::Pointer new_input = this->m_VolumeMSP;
+        
+        // New transform is computed based on this new input, so this new input should be returned to the
+        // BRAINSConstellationDetector2 to be used for the final outputResampledVolume.
+        // "m_OriginalInput" will be returned to the BRAINSConstellationDetector2.
+        DuplicatorType::Pointer duplicator = DuplicatorType::New();
+        duplicator->SetInputImage( new_input );
+        duplicator->Update();
+        this->m_OriginalInput = duplicator->GetOutput();
+        
+        // Before passing the new_input to the ComputeMSP function, we need to find its center of head mass,
+        // and run Hough eye detector on that.
+        std::cout << "\nFinding center of head mass for the MSP estimation output..." << std::endl;
+        itk::FindCenterOfBrainFilter<SImageType>::Pointer findCenterFilter2 = itk::FindCenterOfBrainFilter<SImageType>::New();
+        findCenterFilter2->SetInput( new_input );
+        findCenterFilter2->SetAxis( 2 );
+        findCenterFilter2->SetOtsuPercentileThreshold( 0.01 );
+        findCenterFilter2->SetClosingSize( 7 );
+        findCenterFilter2->SetHeadSizeLimit( 700 );
+        findCenterFilter2->SetBackgroundValue( 0 );
+        findCenterFilter2->Update();
+        SImageType::PointType centerOfHeadMass_new = findCenterFilter2->GetCenterOfBrain();
+        
+        std::cout << "\nFinding eye centers of the MSP estimation output with BRAINS Hough Eye Detector..." << std::endl;
+        itk::BRAINSHoughEyeDetector<SImageType, SImageType>::Pointer houghEyeDetector = 
+                                                                    itk::BRAINSHoughEyeDetector<SImageType, SImageType>::New();
+        houghEyeDetector->SetInput( new_input );
+        houghEyeDetector->SetHoughEyeDetectorMode( 1 );
+        houghEyeDetector->SetWritedebuggingImagesLevel( 0 );
+        houghEyeDetector->SetCenterOfHeadMass( centerOfHeadMass_new );
+        try
+        {
+            houghEyeDetector->Update();
+        }
+        catch( itk::ExceptionObject & excep )
+        {
+            std::cerr << "Cannot find eye centers" << std::endl;
+            std::cerr << excep << std::endl;
+        }
+        catch(...)
+        {
+            std::cout << "Failed to find eye centers exception occured" << std::endl;
+        }
+        
+        this->m_HoughEyeTransform = houghEyeDetector->GetVersorTransform();
+        this->m_LEPoint = houghEyeDetector->GetLE();
+        this->m_REPoint = houghEyeDetector->GetRE();
+        
+        
+        // Transform the new center of head mass by the new hough eye transform.
+        SImageType::PointType houghTransformedCOHM_new =
+        houghEyeDetector->GetInvVersorTransform()->TransformPoint( centerOfHeadMass_new );
+        
+        this->m_CenterOfHeadMass = houghTransformedCOHM_new;
+        
+        // Final estimation of MSP plane
+        std::cout << "\nNew Estimation of MSP..." << std::endl;
+        ComputeMSP( houghEyeDetector->GetOutput(), this->m_finalTmsp,
+                   this->m_VolumeMSP, houghTransformedCOHM_new, this->m_mspQualityLevel, c_c );
+        std::cout << "\n=============================================================" << std::endl;
+    }
+    
+    
   // In case hough eye detector failed
   if( this->m_HoughEyeFailure || ( globalImagedebugLevel > 1 ) )
     {

--- a/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationDetector.h
@@ -91,7 +91,17 @@ public:
 
   void SetVolOrig(SImageType::Pointer image)
   {
-    m_VolOrig = image;
+    m_VolOrig = image;  //This input is the output of Hough Eye detector
+  }
+    
+  void SetOriginalInput(SImageType::Pointer image)
+  {
+    m_OriginalInput = image; // This is the original input of BCD
+  }
+    
+  SImageType::Pointer GetOriginalInput(void) const
+  {
+    return this->m_OriginalInput; // Returns the original input of BCD 
   }
 
   void SetInputTemplateModel(landmarksConstellationModelIO & myModel)
@@ -271,6 +281,7 @@ private:
   SImageType::PointType         m_CenterOfHeadMassEMSP;
   SImageType::PointType         m_BestCenter;
   SImageType::Pointer           m_VolOrig;
+  SImageType::Pointer           m_OriginalInput;
   SImageType::Pointer           m_VolumeMSP;
   landmarksConstellationModelIO m_InputTemplateModel;
   ValMapType                    m_TemplateRadius;


### PR DESCRIPTION
For some input test data, BCD outputs were not proper because BCD could
not estimate the MSP plane correctly based on the reflective correlation
method. Now, BCD tries to give a better
estimation for the MSP plane in cases that the initial estimation has a
large amount of error.
