### PR TITLE
BUG: Fixed number of processors for nipype workflow args to 12 for option 'local_12'

### DIFF
--- a/AutoWorkup/baw_exp.py
+++ b/AutoWorkup/baw_exp.py
@@ -122,7 +122,7 @@ def main(argv=None):
     #  have the same environment as the job submission host.
     JOB_SCRIPT=get_global_sge_script(sys.path,PROGRAM_PATHS,CUSTOM_ENVIRONMENT)
     print JOB_SCRIPT
-	
+
     if input_arguments.wfrun == 'helium_all.q':
         baw200.run(plugin='SGE',
             plugin_args=dict(template=JOB_SCRIPT,qsub_args="-S /bin/bash -pe smp1 1-4 -l mem_free=4000M -o /dev/null -e /dev/null "+CLUSTER_QUEUE))
@@ -138,7 +138,7 @@ def main(argv=None):
     elif input_arguments.wfrun == 'local_12':
         baw200.write_graph()
         print "Running with 12 parallel processes on local machine"
-        baw200.run(plugin='MultiProc', plugin_args={'n_procs' : 4})
+        baw200.run(plugin='MultiProc', plugin_args={'n_procs' : 12})
     elif input_arguments.wfrun == 'local':
         baw200.write_graph()
         print "Running sequentially on local machine"


### PR DESCRIPTION
Small bug I noticed during the tutorial today.
