### PR TITLE
COMP: Add EXTERNAL_PROJECT_BUILD_TYPE

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -30,8 +30,8 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
   // dimensional, and throw an error if
   // B-Spline is before Rigid, or any other non-sensical ordering of the
   // transform types.
-  // Rigid=1, ScaleVersor3D=2, ScaleSkewVersor3D=3, Affine=4, and (BSpline or
-  // ROIBspline)=5
+  // Rigid=1, Similarity3D=2, ScaleVersor3D=3, ScaleSkewVersor3D=4, Affine=5, and (BSpline or
+  // ROIBspline)=6
 #define VTROExceptionMacroMacro()                                       \
   itkGenericExceptionMacro(<< "Ordering of transforms does not proceed from\n" \
                            << "smallest to largest.  Please review settings for transformType.\n" \
@@ -51,7 +51,7 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
         VTROExceptionMacroMacro();
         }
       }
-    else if( transformType[l] == "ScaleVersor3D" )
+    else if( transformType[l] == "Similarity3D" )
       {
       if( CurrentTransformRank <= 2 )
         {
@@ -62,7 +62,7 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
         VTROExceptionMacroMacro();
         }
       }
-    else if( transformType[l] == "ScaleSkewVersor3D" )
+    else if( transformType[l] == "ScaleVersor3D" )
       {
       if( CurrentTransformRank <= 3 )
         {
@@ -73,7 +73,7 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
         VTROExceptionMacroMacro();
         }
       }
-    else if( transformType[l] == "Affine" )
+    else if( transformType[l] == "ScaleSkewVersor3D" )
       {
       if( CurrentTransformRank <= 4 )
         {
@@ -84,7 +84,7 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
         VTROExceptionMacroMacro();
         }
       }
-    else if( transformType[l] == "BSpline" )
+    else if( transformType[l] == "Affine" )
       {
       if( CurrentTransformRank <= 5 )
         {
@@ -95,11 +95,22 @@ ValidateTransformRankOrdering(const std::vector<std::string> & transformType)
         VTROExceptionMacroMacro();
         }
       }
+    else if( transformType[l] == "BSpline" )
+      {
+      if( CurrentTransformRank <= 6 )
+        {
+        CurrentTransformRank = 6;
+        }
+      else
+        {
+        VTROExceptionMacroMacro();
+        }
+      }
     else if( transformType[l] == "ROIBSpline" )
       {
-      if( CurrentTransformRank <= 5 )
+      if( CurrentTransformRank <= 6 )
         {
-        CurrentTransformRank = 5;
+        CurrentTransformRank = 6;
         }
       else
         {
@@ -742,7 +753,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
     //
     // Break into cases on TransformType:
     //
-    if( currentTransformType == "Rigid" )
+if( currentTransformType == "Rigid" )
       {
       //  Choose TransformType for the itk registration class template:
       typedef VersorRigid3DTransformType           TransformType;
@@ -770,7 +781,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             AssignRigid::AssignConvertedTransform(initialITKTransform,
                                                   tempInitializerITKTransform);
             }
-          else if( ( transformFileType == "ScaleVersor3DTransform" )
+          else if( ( transformFileType == "Similarity3DTransform" )
+                   ||( transformFileType == "ScaleVersor3DTransform" )
                    || ( transformFileType == "ScaleSkewVersor3DTransform" )
                    || ( transformFileType == "AffineTransform" ) )
             {
@@ -820,7 +832,102 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
         initialITKTransform);
       localInitializeTransformMode = "Off";   // Now turn of the initiallize
                                               // code to off
+      }
+    else if( currentTransformType == "Similarity3D" )
+      {
+      //  Choose TransformType for the itk registration class template:
+      typedef Similarity3DTransformType    TransformType;
+      typedef itk::VersorTransformOptimizer OptimizerType;
+      // const int NumberOfEstimatedParameter = 7;
 
+      //
+      // Process the initialITKTransform as ScaleVersor3DTransform:
+      //
+      TransformType::Pointer initialITKTransform = TransformType::New();
+      initialITKTransform->SetIdentity();
+      if( m_CurrentGenericTransform.IsNotNull() )
+        {
+        try
+          {
+          const std::string transformFileType = m_CurrentGenericTransform->GetNameOfClass();
+          if( transformFileType == "VersorRigid3DTransform" )
+            {
+            const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(initialITKTransform,
+                                                  tempInitializerITKTransform);
+            }
+          else if( transformFileType == "Similarity3DTransform" )
+            {
+            const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Similarity3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(initialITKTransform,
+                                                  tempInitializerITKTransform);
+            }
+          else if( ( transformFileType == "ScaleVersor3DTransform" )
+                   ||( transformFileType == "ScaleSkewVersor3DTransform" )
+                   || ( transformFileType == "AffineTransform" ) )
+            {
+            // CONVERTING TO RIGID TRANSFORM TYPE from other type:
+            // TODO: we should preserve the Scale components
+            std::cout << "WARNING:  Extracting Rigid component type from transform." << std::endl;
+            VersorRigid3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
+                m_CurrentGenericTransform.GetPointer() );
+            AssignRigid::AssignConvertedTransform( initialITKTransform, tempInitializerITKTransform.GetPointer() );
+            }
+          else              // || transformFileType ==
+                            // "ScaleSkewVersor3DTransform"
+          // ||
+          // transformFileType == "AffineTransform"
+            {
+            std::cout
+            <<
+            "Unsupported initial transform file -- TransformBase first transform typestring, "
+            << transformFileType
+            <<
+            " not equal to required type VersorRigid3DTransform OR ScaleVersor3DTransform"
+            << std::endl;
+            return;
+            }
+          }
+        catch( itk::ExceptionObject & excp )
+          {
+          std::cout << "[FAILED]" << std::endl;
+          std::cerr
+          << "Error while reading the m_CurrentGenericTransform"
+          << std::endl;
+          std::cerr << excp << std::endl;
+          return;
+          }
+        }
+        {
+        // Special optimizations only for the MMI metric
+        // that need adjusting based on both the type of metric, and
+        // the "dimensionality" of the transform being adjusted.
+        typename MattesMutualInformationMetricType::Pointer test_MMICostMetric =
+          dynamic_cast<MattesMutualInformationMetricType *>(this->m_CostMetricObject.GetPointer() );
+        if( test_MMICostMetric.IsNotNull() )
+          {
+          const bool UseExplicitPDFDerivatives =
+            ( m_UseExplicitPDFDerivativesMode == "ON" || m_UseExplicitPDFDerivativesMode == "AUTO" ) ? true : false;
+          test_MMICostMetric->SetUseExplicitPDFDerivatives(UseExplicitPDFDerivatives);
+          }
+        }
+      // #include "FitCommonCode.tmpl"
+      this->FitCommonCode<TransformType, OptimizerType, MetricType>
+        (localNumberOfIterations[currentTransformIndex],
+        localMinimumStepLength[currentTransformIndex],
+        initialITKTransform);
+      localInitializeTransformMode = "Off";   // Now turn of the initiallize
+                                              // code to off
       }
     else if( currentTransformType == "ScaleVersor3D" )
       {
@@ -843,6 +950,17 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             {
             const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
               dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(initialITKTransform,
+                                                  tempInitializerITKTransform);
+            }
+          else if( transformFileType == "Similarity3DTransform" )
+            {
+            const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Similarity3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1021,15 +1139,15 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
       localInitializeTransformMode = "Off";   // Now turn of the initiallize
                                               // code to off
       }
-    else if( currentTransformType == "Affine" )
+    else if( currentTransformType == "ScaleSkewVersor3D" )
       {
       //  Choose TransformType for the itk registration class template:
-      typedef itk::AffineTransform<double, Dimension>  TransformType;
-      typedef itk::RegularStepGradientDescentOptimizer OptimizerType;
-      // const int NumberOfEstimatedParameter = 12;
+      typedef ScaleSkewVersor3DTransformType TransformType;
+      typedef itk::VersorTransformOptimizer  OptimizerType;
+      // const int NumberOfEstimatedParameter = 15;
 
       //
-      // Process the initialITKTransform
+      // Process the initialITKTransform as ScaleSkewVersor3D:
       //
       TransformType::Pointer initialITKTransform = TransformType::New();
       initialITKTransform->SetIdentity();
@@ -1042,6 +1160,17 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             {
             const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
               dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(initialITKTransform,
+                                                  tempInitializerITKTransform);
+            }
+          else if( transformFileType == "Similarity3DTransform" )
+            {
+            const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Similarity3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1071,25 +1200,25 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             AssignRigid::AssignConvertedTransform(initialITKTransform,
                                                   tempInitializerITKTransform);
             }
-          else if( transformFileType == "AffineTransform" )
+          else if( ( transformFileType == "AffineTransform" ) )
             {
-            const AffineTransformType::ConstPointer tempInitializerITKTransform =
-              dynamic_cast<AffineTransformType const *>( m_CurrentGenericTransform.GetPointer() );
-            if( tempInitializerITKTransform.IsNull() )
-              {
-              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
-              }
-            AssignRigid::AssignConvertedTransform(initialITKTransform,
-                                                  tempInitializerITKTransform);
+            // CONVERTING TO RIGID TRANSFORM TYPE from other type:
+            // TODO:  We should really preserve the Scale and Skew components
+            std::cout << "WARNING:  Extracting Rigid component type from transform." << std::endl;
+            VersorRigid3DTransformType::Pointer tempInitializerITKTransform = ComputeRigidTransformFromGeneric(
+                m_CurrentGenericTransform.GetPointer() );
+            AssignRigid::AssignConvertedTransform( initialITKTransform, tempInitializerITKTransform.GetPointer() );
             }
-          else              //  NO SUCH CASE!!
+          else              // || transformFileType == "AffineTransform" ||
+          // transformFileType
+          // == "ScaleVersor3DTransform"
             {
             std::cout
             <<
             "Unsupported initial transform file -- TransformBase first transform typestring, "
             << transformFileType
-            << " not equal to any recognized type VersorRigid3DTransform OR "
-            << "ScaleVersor3DTransform OR ScaleSkewVersor3DTransform OR AffineTransform"
+            << " not equal to required type VersorRigid3DTransform "
+            << "OR ScaleVersor3DTransform OR ScaleSkewVersor3DTransform"
             << std::endl;
             return;
             }
@@ -1104,7 +1233,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           return;
           }
         }
-
         {
         // Special optimizations only for the MMI metric
         // that need adjusting based on both the type of metric, and
@@ -1169,6 +1297,18 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             {
             const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
               dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
+                                                  tempInitializerITKTransform);
+            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
+            }
+          else if( transformFileType == "Similarity3DTransform" )
+            {
+            const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Similarity3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
@@ -1481,6 +1621,18 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
             {
             const VersorRigid3DTransformType::ConstPointer tempInitializerITKTransform =
               dynamic_cast<VersorRigid3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
+            if( tempInitializerITKTransform.IsNull() )
+              {
+              std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;
+              }
+            AssignRigid::AssignConvertedTransform(bulkAffineTransform,
+                                                  tempInitializerITKTransform);
+            initialBSplineTransform->SetBulkTransform(bulkAffineTransform);
+            }
+          else if( transformFileType == "Similarity3DTransform" )
+            {
+            const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+              dynamic_cast<Similarity3DTransformType const *>( m_CurrentGenericTransform.GetPointer() );
             if( tempInitializerITKTransform.IsNull() )
               {
               std::cout << "Error in type conversion" << __FILE__ << __LINE__ << std::endl;

--- a/BRAINSCommonLib/BRAINSFitUtils.h
+++ b/BRAINSCommonLib/BRAINSFitUtils.h
@@ -7,6 +7,7 @@
 #include "itkScaleVersor3DTransform.h"
 #include "itkScaleSkewVersor3DTransform.h"
 #include "itkAffineTransform.h"
+#include "itkSimilarity3DTransform.h"
 #include "itkVersorRigid3DTransform.h"
 #include "itkBSplineDeformableTransform.h"
 #include "itkBRAINSROIAutoImageFilter.h"
@@ -27,6 +28,7 @@ typedef itk::BSplineDeformableTransform<
   BFNSplineOrder>                                        BSplineTransformType;
 
 typedef itk::VersorRigid3DTransform<double>              VersorRigid3DTransformType;
+typedef itk::Similarity3DTransform<double>               Similarity3DTransformType;
 typedef itk::ScaleVersor3DTransform<double>              ScaleVersor3DTransformType;
 typedef itk::ScaleSkewVersor3DTransform<double>          ScaleSkewVersor3DTransformType;
 typedef itk::AffineTransform<double, BFNSSpaceDimension> AffineTransformType;

--- a/BRAINSCommonLib/ConvertToRigidAffine.h
+++ b/BRAINSCommonLib/ConvertToRigidAffine.h
@@ -3,6 +3,7 @@
 #include <itkMatrix.h>
 #include <itkVector.h>
 #include <itkAffineTransform.h>
+#include <itkSimilarity3DTransform.h>
 #include <itkVersorRigid3DTransform.h>
 #include "itkScaleVersor3DTransform.h"
 #include "itkScaleSkewVersor3DTransform.h"
@@ -35,6 +36,12 @@ typedef VersorRigid3DTransformType::Pointer
 VersorRigid3DTransformPointer;
 typedef VersorRigid3DTransformType::ParametersType
 VersorRigid3DParametersType;
+
+typedef itk::Similarity3DTransform<double>
+Similarity3DTransformType;
+typedef Similarity3DTransformType::Pointer Similarity3DTransformPointer;
+typedef Similarity3DTransformType::ParametersType
+Similarity3DParametersType;
 
 typedef itk::ScaleVersor3DTransform<double>
 ScaleVersor3DTransformType;
@@ -353,6 +360,153 @@ inline void AssignConvertedTransform(
     std::cout
     <<
     "Error missing Pointer data, assigning ScaleVersor3DTransformPointer := VersorRigid3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+/**
+  * AffineTransformPointer  :=  Similarity3DTransformPointer
+  */
+
+inline void
+AssignConvertedTransform(AffineTransformPointer & result,
+                         const Similarity3DTransformType::ConstPointer similarityVersor)
+{
+  if( result.IsNotNull() && similarityVersor.IsNotNull() )
+    {
+    result->SetIdentity();
+    result->SetCenter( similarityVersor->GetCenter() );
+    result->SetMatrix( similarityVersor->GetMatrix() );       // NOTE:  This matrix has
+                                                   // both
+    // rotation ans scale components.
+    result->SetTranslation( similarityVersor->GetTranslation() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning AffineTransformPointer := ScaleVersor3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+/**
+  * ScaleSkewVersor3DTransformPointer  :=  Similarity3DTransformPointer
+  */
+inline void AssignConvertedTransform(
+  ScaleSkewVersor3DTransformPointer & result,
+  const Similarity3DTransformType::ConstPointer similarityVersor)
+{
+  if( result.IsNotNull() && similarityVersor.IsNotNull() )
+    {
+    result->SetIdentity();
+    result->SetCenter( similarityVersor->GetCenter() );
+    result->SetRotation( similarityVersor->GetVersor() );
+    ScaleSkewVersor3DTransformType::ScaleVectorType scale;
+    scale.Fill(similarityVersor->GetScale()); 
+    result->SetScale( scale );
+    result->SetTranslation( similarityVersor->GetTranslation() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning ScaleSkewVersor3DTransformPointer := Similarity3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+/**
+  * ScaleVersor3DTransformPointer  :=  Similarity3DTransformPointer
+  */
+inline void AssignConvertedTransform(
+  ScaleVersor3DTransformPointer & result,
+  const Similarity3DTransformType::ConstPointer similarityVersor)
+{
+  if( result.IsNotNull() && similarityVersor.IsNotNull() )
+    {
+    result->SetIdentity();
+    result->SetCenter( similarityVersor->GetCenter() );
+    result->SetRotation( similarityVersor->GetVersor() );
+    result->SetTranslation( similarityVersor->GetTranslation() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning ScaleVersor3DTransformPointer := Similarity3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+
+/**
+  * Similarity3DTransformPointer  :=  Similarity3DTransformPointer
+  */
+
+inline void
+AssignConvertedTransform(Similarity3DTransformPointer & result,
+                         const Similarity3DTransformType::ConstPointer similarityVersor)
+{
+  if( result.IsNotNull() && similarityVersor.IsNotNull() )
+    {
+    result->SetParameters( similarityVersor->GetParameters() );
+    result->SetFixedParameters( similarityVersor->GetFixedParameters() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning Similarity3DTransform := Similarity3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+/**
+  * Similarity3DTransformPointer  :=  VersorRigid3DTransformPointer
+  */
+inline void AssignConvertedTransform(
+  Similarity3DTransformPointer & result,
+  const VersorRigid3DTransformType::ConstPointer versorRigid)
+{
+  if( result.IsNotNull() && versorRigid.IsNotNull() )
+    {
+    result->SetIdentity();
+    result->SetCenter( versorRigid->GetCenter() );
+    result->SetRotation( versorRigid->GetVersor() );
+    result->SetTranslation( versorRigid->GetTranslation() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning Similarity3DTransformPointer := VersorRigid3DTransformPointer."
+    << std::endl;
+    throw;
+    }
+}
+
+inline void ExtractVersorRigid3DTransform(
+  VersorRigid3DTransformPointer & result,
+  const Similarity3DTransformType::ConstPointer similarityVersor)
+{
+  if( result.IsNotNull() && similarityVersor.IsNotNull() )
+    {
+    result->SetIdentity();
+    result->SetCenter( similarityVersor->GetCenter() );
+    result->SetRotation( similarityVersor->GetVersor() );
+    result->SetTranslation( similarityVersor->GetTranslation() );
+    }
+  else
+    {
+    std::cout
+    <<
+    "Error missing Pointer data, assigning VersorRigid3DTransformPointer := Similarity3DTransformPointer."
     << std::endl;
     throw;
     }

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -56,6 +56,16 @@ VersorRigid3DTransformType::Pointer ComputeRigidTransformFromGeneric(
           }
         AssignRigid::ExtractVersorRigid3DTransform(versorRigid, tempInitializerITKTransform);
         }
+      else if( transformFileType == "Similarity3DTransform" )
+        {
+        const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+          dynamic_cast<Similarity3DTransformType const *>( genericTransformToWrite.GetPointer() );
+        if( tempInitializerITKTransform.IsNull() )
+          {
+          itkGenericExceptionMacro(<< "Error in type conversion");
+          }
+        AssignRigid::ExtractVersorRigid3DTransform(versorRigid, tempInitializerITKTransform);
+        }
       else if( transformFileType == "ScaleVersor3DTransform" )
         {
         const ScaleVersor3DTransformType::ConstPointer tempInitializerITKTransform =
@@ -142,6 +152,13 @@ int WriteBothTransformsToDisk(const GenericTransformType::ConstPointer genericTr
     {
     const std::string transformFileType = genericTransformToWrite->GetNameOfClass();
     if( transformFileType == "VersorRigid3DTransform" )
+      {
+      if( outputTransform.size() > 0 )  // Write out the transform
+        {
+        itk::WriteTransformToDisk(genericTransformToWrite, outputTransform);
+        }
+      }
+    else if( transformFileType == "Similarity3DTransform" )
       {
       if( outputTransform.size() > 0 )  // Write out the transform
         {
@@ -267,6 +284,19 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
         itkGenericExceptionMacro(<< "Error in type conversion");
         }
       VersorRigid3DTransformType::Pointer tempCopy = VersorRigid3DTransformType::New();
+      AssignRigid::AssignConvertedTransform(tempCopy,
+                                            tempInitializerITKTransform);
+      genericTransform = tempCopy.GetPointer();
+      }
+    else if( transformFileType == "Similarity3DTransform" )
+      {
+      const Similarity3DTransformType::ConstPointer tempInitializerITKTransform =
+        dynamic_cast<Similarity3DTransformType const *>( ( *( currentTransformList.begin() ) ).GetPointer() );
+      if( tempInitializerITKTransform.IsNull() )
+        {
+        itkGenericExceptionMacro(<< "Error in type conversion");
+        }
+      Similarity3DTransformType::Pointer tempCopy = Similarity3DTransformType::New();
       AssignRigid::AssignConvertedTransform(tempCopy,
                                             tempInitializerITKTransform);
       genericTransform = tempCopy.GetPointer();
@@ -494,7 +524,8 @@ void AddExtraTransformRegister(void)
   itk::TransformFactory<itk::ScaleVersor3DTransform<float> >::RegisterDefaultTransforms();
   itk::TransformFactory<itk::ScaleVersor3DTransform<double> >::RegisterTransform();
   itk::TransformFactory<itk::ScaleVersor3DTransform<float> >::RegisterTransform();
-
+  itk::TransformFactory<itk::Similarity3DTransform<double> >::RegisterTransform();
+  itk::TransformFactory<itk::Similarity3DTransform<float> >::RegisterTransform();
   itk::TransformFactory<itk::AffineTransform<double, 2> >::RegisterTransform();
   itk::TransformFactory<itk::AffineTransform<double, 3> >::RegisterTransform();
   itk::TransformFactory<itk::BSplineDeformableTransform<double, 2, 2> >::RegisterTransform();

--- a/BRAINSCommonLib/GenericTransformImage.h
+++ b/BRAINSCommonLib/GenericTransformImage.h
@@ -16,6 +16,7 @@
 #include "itkSignedMaurerDistanceMapImageFilter.h"
 #include "itkStatisticsImageFilter.h"
 #include "itkScaleVersor3DTransform.h"
+#include "itkSimilarity3DTransform.h"
 #include "itkScaleSkewVersor3DTransform.h"
 #include "itkAffineTransform.h"
 #include <itkBSplineDeformableTransform.h>
@@ -55,6 +56,7 @@ typedef itk::BSplineDeformableTransform<
 
 typedef itk::AffineTransform<double, 3>                      AffineTransformType;
 typedef itk::VersorRigid3DTransform<double>                  VersorRigid3DTransformType;
+typedef itk::Similarity3DTransform<double>                  Similarity3DTransformType;
 typedef itk::ScaleVersor3DTransform<double>                  ScaleVersor3DTransformType;
 typedef itk::ScaleSkewVersor3DTransform<double>              ScaleSkewVersor3DTransformType;
 typedef itk::ThinPlateR2LogRSplineKernelTransform<double, 3> ThinPlateSpline3DTransformType;

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -263,6 +263,21 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
       optimizerScales[i] = reproportionScale;
       }
     }
+  else if( m_Transform->GetNumberOfParameters() == 7 )    // Similarity3D
+    {
+    for( unsigned int i = 0; i < 3; ++i )
+      {
+      optimizerScales[i] = 1.0;
+      }
+    for( unsigned int i = 3; i < 6; ++i )
+      {
+      optimizerScales[i] = translationScale;
+      }
+    for( unsigned int i = 6; i < 7; ++i )
+      {
+      optimizerScales[i] = reproportionScale;
+      }
+    }
   else if( m_Transform->GetNumberOfParameters() == 6 )     //  VersorRigid3D
     {
     for( unsigned int i = 0; i < 3; ++i )

--- a/BRAINSFit/BRAINSFit.cxx
+++ b/BRAINSFit/BRAINSFit.cxx
@@ -152,6 +152,7 @@ int main(int argc, char *argv[])
   // transforms.
   //
   itk::TransformFactory<VersorRigid3DTransformType>::RegisterTransform();
+  itk::TransformFactory<Similarity3DTransformType>::RegisterTransform();
   itk::TransformFactory<ScaleVersor3DTransformType>::RegisterTransform();
   itk::TransformFactory<ScaleSkewVersor3DTransformType>::RegisterTransform();
   itk::TransformFactory<AffineTransformType>::RegisterTransform();
@@ -187,13 +188,17 @@ int main(int argc, char *argv[])
   std::vector<std::string> localTransformType;
   // See if the individual boolean registration options are being used.  If any
   // of these are set, then transformType is not used.
-  if( ( useRigid == true ) || ( useScaleVersor3D == true ) || ( useScaleSkewVersor3D == true )
+  if( ( useRigid == true ) || (useSimilarity3D == true) || ( useScaleVersor3D == true ) || ( useScaleSkewVersor3D == true )
       || ( useAffine == true ) || ( useBSpline == true ) )
     {
     localTransformType.resize(0); // Set to zero length
     if( useRigid == true )
       {
       localTransformType.push_back("Rigid");
+      }
+    if( useSimilarity3D == true )
+      {
+      localTransformType.push_back("Similarity3D");
       }
     if( useScaleVersor3D == true )
       {

--- a/BRAINSFit/BRAINSFit.xml
+++ b/BRAINSFit/BRAINSFit.xml
@@ -96,9 +96,16 @@
        <default>false</default>
     </boolean>
     <boolean>
+       <name>useSimilarity3D</name>
+       <longflag>useSimilarity3D</longflag>
+       <label>Rigid+IsotropicScale(7 DOF)</label>
+       <description>Perform a Similarity3D registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
+       <default>false</default>
+    </boolean>
+    <boolean>
        <name>useScaleVersor3D</name>
        <longflag>useScaleVersor3D</longflag>
-       <label>Rigid+Scale(7 DOF)</label>
+       <label>Rigid+AnisotropicScale(9 DOF)</label>
        <description>Perform a ScaleVersor3D registration as part of the sequential registration steps.  This family of options superceeds the use of transformType if any of them are set.</description>
        <default>false</default>
     </boolean>


### PR DESCRIPTION
By default build all libraries that BRAINSTools depends on in
Release mode.  In other words even if the BRAINSTools apps are
built in Debug mode they'll be linking (by default) to release mode
libraries.
