### PR TITLE
ENH: Download NiPype

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -119,6 +119,9 @@ if(USE_ANTS)
   list(APPEND ${LOCAL_PROJECT_NAME}_DEPENDENCIES ANTS)
 endif()
 
+if(USE_AutoWorkup)
+  list(APPEND ${LOCAL_PROJECT_NAME}_DEPENDENCIES NIPYPE)
+endif()
 
 #-----------------------------------------------------------------------------
 # Define Superbuild global variables

--- a/SuperBuild/External_NIPYPE.cmake
+++ b/SuperBuild/External_NIPYPE.cmake
@@ -1,0 +1,20 @@
+# Make sure this file is included only once
+get_filename_component(CMAKE_CURRENT_LIST_FILENAME ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
+if(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED)
+  return()
+endif()
+set(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED 1)
+
+set(proj NIPYPE)
+set(${proj}_GIT_REPOSITORY "git://github.com/nipy/nipype.git")
+set(${proj}_GIT_TAG "a77edf9ba9a8f2c21b220a247bbfba72d07b5e40")
+
+ExternalProject_Add(${proj}
+  GIT_REPOSITORY ${${proj}_GIT_REPOSITORY}
+  GIT_TAG ${${proj}_GIT_TAG}
+  SOURCE_DIR ${proj}
+  UPDATE_COMMAND ""
+  CONFIGURE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  )


### PR DESCRIPTION
NOTE: testing this ended up triggering a complete ITK build, so my only testing right at the moment is that it doesn't prevent a successful CMake configure.  It looks as though it works fine, give it a try.

Use a vacuous ExternalProject that does nothing but download the
Nipype source from github.  It would be possible to extract just
the git download script from ExternalProject_add, but it's more
complicated than just calling ExternalProject_Add.
