### PR TITLE
B cut test fix

### DIFF
--- a/BRAINSCut/BRAINSCutGenerateProbability.h
+++ b/BRAINSCut/BRAINSCutGenerateProbability.h
@@ -33,7 +33,8 @@ private:
                                                   const std::string & ImageName,
                                                   typename WarperImageType::Pointer ReferenceImage  )
   {
-    const bool useTransform = ( RegistrationFilename.find(".mat") != std::string::npos );
+    const bool useTransform = ( RegistrationFilename.find(".mat") != std::string::npos ||
+                                RegistrationFilename.find(".h5") != std::string::npos );
 
     typename WarperImageType::Pointer PrincipalOperandImage; // One name for the
                                                              // image to be

--- a/BRAINSCut/BRAINSCutUtilities.cxx
+++ b/BRAINSCut/BRAINSCutUtilities.cxx
@@ -44,10 +44,12 @@ WorkingImagePointer ReadImageByFilename( const std::string  filename )
 
 DisplacementFieldType::Pointer GetDeformationField( std::string filename)
 {
-  const bool useTransform( filename.find(".mat") != std::string::npos );
+  const bool useTransform( filename.find(".mat") == std::string::npos || 
+                           filename.find(".h5") == std::string::npos );
 
   if( useTransform )
     {
+    std::cout << "Return null deformation. Use transformation instead." << std::endl;
     return NULL;
     }
   typedef itk::ImageFileReader<DisplacementFieldType> DeformationReaderType;
@@ -60,11 +62,13 @@ DisplacementFieldType::Pointer GetDeformationField( std::string filename)
 
 GenericTransformType::Pointer GetGenericTransform( std::string filename)
 {
-  const bool useDeformation( filename.find(".mat") == std::string::npos );
+  const bool useDeformation( filename.find(".mat") != std::string::npos &&
+                             filename.find(".h5") != std::string::npos &&
+                             filename.find(".txt") != std::string::npos );
 
   if( useDeformation )
     {
-    std::cout << "return null deformation" << std::endl;
+    std::cout << "Return null transformation. Use deformation instead." << std::endl;
     return NULL;
     }
   return itk::ReadTransformFromDisk( filename );

--- a/BRAINSCut/CMakeLists.txt
+++ b/BRAINSCut/CMakeLists.txt
@@ -54,11 +54,11 @@ foreach( prog ${ALL_PROGS_LIST} )
   StandardBRAINSBuildMacro( NAME ${prog} TARGET_LIBRARIES BRAINSCutCOMMONLIB )
 endforeach()
 
-if(0) ## HACK Regina many tests are failing and needs investigation,
+if(1) ## HACK Regina many tests are failing and needs investigation,
       ## HACK Regina some tests are segmentation faulting
+  add_subdirectory(TestSuite)
+endif()
 if(BUILD_TESTING)
   add_executable(TestHashKey TestHashKey.cxx)
   target_link_libraries(TestHashKey BRAINSCutCOMMONLIB)
-  add_subdirectory(TestSuite)
-endif()
 endif()


### PR DESCRIPTION
BRAINSCut Test is now working. 
The issue was the deformation file extension has been changed to _**.h5 from *_*.mat/txt/nii.gz in ITK4. The logic in BCut now supports for h5 file format in proper way and tested in wundt, all tests are passing. 
