### PR TITLE
COMP: add hack to find Python includes on weird systems

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -28,7 +28,25 @@ configure_file(SuperBuild/SimpleITK_install_step.cmake.in
 
 set(SimpleITK_INSTALL_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK_install_step.cmake)
 
+find_package( PythonInterp REQUIRED )
+find_package ( PythonLibs REQUIRED )
 
+#
+# On the Helium machine I ran into trouble with
+# SimpleITK not being able to find Python.h.
+# After sleuthing around I determined that
+# PYTHON_INCLUDE_DIRS pointed to the parent of the
+# directory containing Python.h, So if that's
+# the case I search for it and amend the patch.
+if(NOT EXISTS "${PYTHON_INCLUDE_DIRS}/Python.h")
+  file(GLOB_RECURSE PYTHON_H "${PYTHON_INCLUDE_DIRS}/Python.h")
+  get_filename_component(PYTHON_INCLUDE_DIRS ${PYTHON_H} PATH )
+  set(PYTHON_INCLUDE_PATH ${PYTHON_INCLUDE_DIRS})
+#  message("PYTHON_INCLUDE_DIRS=${PYTHON_INCLUDE_DIRS}")
+endif()
+
+#
+# 
 ExternalProject_add(SimpleITK
   SOURCE_DIR SimpleITK
   BINARY_DIR SimpleITK-build
@@ -37,7 +55,7 @@ ExternalProject_add(SimpleITK
   "${cmakeversion_external_update}"
   CMAKE_ARGS
     -Wno-dev
-    --no-warn-unused-cli
+#    --no-warn-unused-cli
     -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
     -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
@@ -48,7 +66,6 @@ ExternalProject_add(SimpleITK
   -DBUILD_SHARED_LIBS:BOOL=OFF
   -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}
   -DITK_DIR:PATH=${ITK_DIR}
-  -DBUILD_EXAMPLES:BOOL=OFF
   -DBUILD_TESTING:BOOL=OFF
   -DBUILD_DOXYGEN:BOOL=OFF
   -DWRAP_PYTHON:BOOL=ON
@@ -58,6 +75,10 @@ ExternalProject_add(SimpleITK
   -DWRAP_LUA:BOOL=OFF
   -DWRAP_CSHARP:BOOL=OFF
   -DWRAP_R:BOOL=OFF
+  -DPYTHON_LIBRARIES:STRING=${PYTHON_LIBRARIES}
+  -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIRS}
+  -DPYTHON_INCLUDE_DIRS:PATH=${PYTHON_INCLUDE_DIRS}
+  -DPYTHON_DEBUG_LIBRARIES:STRING=${PYTHON_DEBUG_LIBRARIES}
   -DSWIG_EXECUTABLE:PATH=${SWIG_EXECUTABLE}
   #
   INSTALL_COMMAND ${SimpleITK_INSTALL_COMMAND}


### PR DESCRIPTION
Ran into this building BRAINSStandAlone on the Helium cluster. SimpleITK wouldn't build because it couldn't find Python.h.

The problem, as near as I can figure is that while FindPython.cmake works, the way that Python 2.6 and 2.7 are installed on the helium cluster isn't what FindPython expects.  Instead of having Python headers in <Python_Prefix>/include they''re in <Python_Prefix>/include/Python-<Python_Version>

This fixes the problem by finding the Python.h file, and putting that file's path in as PYTHON_INCLUDE_DIRS.
