### PR TITLE
ENH: Add ConvertBetweenFileFormats

### DIFF
--- a/BRAINSTools.cmake
+++ b/BRAINSTools.cmake
@@ -101,6 +101,7 @@ set(brains_modulenames
   BRAINSTransformConvert
   BRAINSConstellationDetector
   BRAINSABC
+  ConvertBetweenFileFormats
 )
 
 if(USE_DebugImageViewer)

--- a/Common.cmake
+++ b/Common.cmake
@@ -49,6 +49,7 @@ option(USE_BRAINSCut                      "Build BRAINSCut"                     
 option(USE_BRAINSLandmarkInitializer      "Build BRAINSLandmarkInitializer"      ON)
 option(USE_ImageCalculator                "Build ImageCalculator"                ON)
 option(USE_BRAINSSnapShotWriter           "Build BRAINSSnapShotWriter"           ON)
+option(USE_ConvertBetweenFileFormats      "Build ConvertBetweenFileFormats"      ON)
 if( NOT USE_ANTS )
 option(USE_ANTS                           "Build ANTS"                           ON)
 endif()

--- a/ConvertBetweenFileFormats/CMakeLists.txt
+++ b/ConvertBetweenFileFormats/CMakeLists.txt
@@ -1,0 +1,100 @@
+# This project is intended to be built outside the Insight source tree
+PROJECT(ConvertBetweenFileFormats)
+
+CONFIGURE_FILE( ${CMAKE_CURRENT_SOURCE_DIR}/castconvertConfigure.h.in 
+                ${CMAKE_CURRENT_BINARY_DIR}/castconvertConfigure.h @ONLY IMMEDIATE )
+
+ADD_EXECUTABLE(ConvertBetweenFileFormats castconvert.cxx  castconvertDicomScalar.cxx castconvertScalar.cxx  castconvertScalar2D.cxx castconvertScalar3D.cxx castconvertScalar4D.cxx castconvertScalar4DA.cxx castconvertScalar2DA.cxx castconvertScalar3DA.cxx castconvertDicomScalarA.cxx)
+
+INCLUDE_DIRECTORIES( 
+    ${CMAKE_CURRENT_SOURCE_DIR} 
+    ${CMAKE_CURRENT_BINARY_DIR} 
+    )
+
+TARGET_LINK_LIBRARIES(ConvertBetweenFileFormats  ${ITK_LIBRARIES} )
+IF (VTK_FOUND)
+  TARGET_LINK_LIBRARIES(ConvertBetweenFileFormats vtkIO vtkCommon vtkFiltering vtkImaging )
+  INCLUDE_DIRECTORIES( ${ITKApps_SOURCE_DIR}/Auxiliary/vtk )
+ENDIF (VTK_FOUND)
+
+INSTALL_TARGETS(/bin ConvertBetweenFileFormats)
+
+IF( BUILD_TESTING )
+  SET(CXX_TEST_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  SET(CONVERT_TESTS ${CXX_TEST_PATH}/ConvertBetweenFileFormats)
+
+  SET(IMAGE_PATH ${ConvertBetweenFileFormats_SOURCE_DIR}/Testing/Data)
+  SET(IMAGE_PATH_OUTPUTS ${ConvertBetweenFileFormats_BINARY_DIR})
+  # Convert from grayscale mhd to other image file formats
+  ADD_TEST(ccvnt_to_png                   ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.png)
+  ADD_TEST(ccvnt_to_jpg_unsigned_int      ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.jpg unsigned_int)
+  ADD_TEST(ccvnt_to_tiff                  ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.tiff)
+  ADD_TEST(ccvnt_to_analyze75             ${CONVERT_TESTS} ${IMAGE_PATH}/BigEndian.mhd ${IMAGE_PATH_OUTPUTS}/image_out.img)
+  ADD_TEST(ccvnt_to_bmp_unsigned_char     ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.bmp unsigned_char)
+  ADD_TEST(ccvnt_to_nrrd_float            ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.nrrd float)
+  ADD_TEST(ccvnt_to_vtk_long              ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.vtk long)
+  ADD_TEST(ccvnt_to_gipl                  ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.gipl)
+  ADD_TEST(ccvnt_to_nifti                 ${CONVERT_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_out.nii.gz)
+
+  # Convert back to mhd
+  ADD_TEST(ccvnt_from_png                 ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.png    ${IMAGE_PATH_OUTPUTS}/image_in1.mhd)
+  set_tests_properties(ccvnt_from_png PROPERTIES DEPENDS ccvnt_to_png)
+
+  ADD_TEST(ccvnt_from_jpg_unsigned_int    ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.jpg    ${IMAGE_PATH_OUTPUTS}/image_in2.mhd unsigned_short)
+  set_tests_properties(ccvnt_from_jpg_unsigned_int PROPERTIES DEPENDS ccvnt_to_jpg_unsigned_int)
+
+  ADD_TEST(ccvnt_from_tiff                ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.tiff   ${IMAGE_PATH_OUTPUTS}/image_in3.mhd)
+  set_tests_properties(ccvnt_from_tiff PROPERTIES DEPENDS ccvnt_to_tiff)
+
+  ADD_TEST(ccvnt_from_analyze75           ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.hdr    ${IMAGE_PATH_OUTPUTS}/image_in4.mhd)
+  set_tests_properties(ccvnt_from_analyze75 PROPERTIES DEPENDS ccvnt_to_analyze75)
+
+  #
+  # Disabling this test because BMP are now only supporting reading of RGB images.
+  # ADD_TEST(ccvnt_from_bmp_unsigned_char   ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.bmp    ${IMAGE_PATH_OUTPUTS}/image_in5.mhd unsigned_short)
+  #
+  ADD_TEST(ccvnt_from_nrrd_float          ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.nrrd   ${IMAGE_PATH_OUTPUTS}/image_in6.mhd unsigned_short)
+  set_tests_properties(ccvnt_from_nrrd_float PROPERTIES DEPENDS ccvnt_to_nrrd_float)
+
+  ADD_TEST(ccvnt_from_vtk_long            ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.vtk    ${IMAGE_PATH_OUTPUTS}/image_in7.mhd unsigned_short)
+  set_tests_properties(ccvnt_from_vtk_long PROPERTIES DEPENDS ccvnt_to_vtk_long)
+
+  ADD_TEST(ccvnt_from_gipl                ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.gipl   ${IMAGE_PATH_OUTPUTS}/image_in8.mhd)
+  set_tests_properties(ccvnt_from_gipl PROPERTIES DEPENDS ccvnt_to_gipl)
+
+  ADD_TEST(ccvnt_from_nifti               ${CONVERT_TESTS} ${IMAGE_PATH_OUTPUTS}/image_out.nii.gz ${IMAGE_PATH_OUTPUTS}/image_in8.mhd)
+  set_tests_properties(ccvnt_from_nifti PROPERTIES DEPENDS ccvnt_to_nifti)
+
+  SET(IMAGE_COMPARE_TESTS ${CXX_TEST_PATH}/ImageCompareTests)
+
+  # Compare with original png
+  ADD_TEST(compare_png                    ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in1.mhd Dummy)
+  set_tests_properties(compare_png PROPERTIES DEPENDS ccvnt_from_png)
+
+ #ADD_TEST(compare_jpg_unsigned_int       ${IMAGE_COMPARE_TESTS} ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in2.mhd)
+  ADD_TEST(compare_tiff                   ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in3.mhd Dummy)
+  set_tests_properties(compare_tiff PROPERTIES DEPENDS ccvnt_from_tiff)
+
+  ADD_TEST(compare_analyze75              ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/BigEndian.mhd ${IMAGE_PATH_OUTPUTS}/image_in4.mhd Dummy)
+  set_tests_properties(compare_analyze75 PROPERTIES DEPENDS ccvnt_from_analyze75)
+
+  #
+  # Disabling this test because BMP are now only supporting reading of RGB images.
+  # ADD_TEST(compare_bmp_unsigned_char      ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in5.mhd Dummy)
+  #
+  ADD_TEST(compare_nrrd_float             ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in6.mhd Dummy)
+  set_tests_properties(compare_nrrd_float PROPERTIES DEPENDS ccvnt_from_nrrd_float)
+
+  ADD_TEST(compare_vtk_long               ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in7.mhd Dummy)
+  set_tests_properties(compare_vtk_long PROPERTIES DEPENDS ccvnt_from_vtk_long)
+
+  ADD_TEST(compare_gipl                   ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in8.mhd Dummy)
+  set_tests_properties(compare_gipl PROPERTIES DEPENDS ccvnt_from_gipl)
+
+  ADD_TEST(compare_nifti            ${IMAGE_COMPARE_TESTS} --compare ${IMAGE_PATH}/image_in.mhd ${IMAGE_PATH_OUTPUTS}/image_in8.mhd Dummy)
+  set_tests_properties(compare_nifti PROPERTIES DEPENDS ccvnt_from_nifti)
+
+  ADD_EXECUTABLE(ImageCompareTests ImageCompareTests.cxx)
+  TARGET_LINK_LIBRARIES(ImageCompareTests ${ITK_LIBRARIES})
+ENDIF( BUILD_TESTING )
+

--- a/ConvertBetweenFileFormats/ImageCompareTests.cxx
+++ b/ConvertBetweenFileFormats/ImageCompareTests.cxx
@@ -1,0 +1,20 @@
+// this file defines the ImageCompare-Tests for the test driver
+// and all it expects is that you have a function called RegisterTests
+#if defined(_MSC_VER)
+#pragma warning ( disable : 4786 )
+#endif
+#include <iostream>
+#include "itkTestMain.h" 
+
+// A dummy method that does nothing. We intend doing a comparison which is done
+// by the itkTestMain.h. (It requires a main program, prior to the compare)
+int Dummy(int, char *[])
+{
+  return EXIT_SUCCESS;
+}
+
+void RegisterTests()
+{
+REGISTER_TEST(Dummy);
+}
+

--- a/ConvertBetweenFileFormats/Testing/Data/BigEndian.mhd
+++ b/ConvertBetweenFileFormats/Testing/Data/BigEndian.mhd
@@ -1,0 +1,13 @@
+ObjectType = Image
+NDims = 3
+BinaryData = True
+BinaryDataByteOrderMSB = False
+CompressedData = False
+TransformMatrix = 1 0 0 0 0 1 0 -1 0
+Offset = 0 0 0
+CenterOfRotation = 0 0 0
+AnatomicalOrientation = RIP
+ElementSpacing = 1 1 1
+DimSize = 6 6 8
+ElementType = MET_SHORT
+ElementDataFile = BigEndian.raw

--- a/ConvertBetweenFileFormats/Testing/Data/image_in.mhd
+++ b/ConvertBetweenFileFormats/Testing/Data/image_in.mhd
@@ -1,0 +1,12 @@
+ObjectType = Image
+NDims = 2
+BinaryData = True
+BinaryDataByteOrderMSB = False
+TransformMatrix = 1 0 0 1
+Offset = 0 0
+CenterOfRotation = 0 0
+ElementSpacing = 1 1
+DimSize = 181 217
+AnatomicalOrientation = ??
+ElementType = MET_USHORT
+ElementDataFile = image_in.raw

--- a/ConvertBetweenFileFormats/castconvert.cxx
+++ b/ConvertBetweenFileFormats/castconvert.cxx
@@ -1,0 +1,349 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvert.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+/**
+ * castconvert
+ *
+ * This program converts and possibly casts images.
+ *
+ * This is done by reading in an image, possibly casting of the image,
+ * and subsequently writing the image to some format.
+ * With converting we mean changing the extension of the image,
+ * such as bmp, mhd, etc. With casting we mean changing the component
+ * type of a voxel, such as short, unsigned long, float.
+ *
+ * Casting is currently done using the ShiftScaleImageFilter,
+ * where values are mapped to itself, leaving the intensity range
+ * the same. NOTE that when casting to a component type with a
+ * smaller dynamic range, information might get lost. In this case
+ * we might use the RescaleIntensityImageFilter to linearly
+ * rescale the image values.
+ *
+ * Currently only supported are the SCALAR pixel types.
+ * Input images can be in all file formats ITK supports and for which
+ * the ImageFileReader works, and additionally single 3D dicom series
+ * using the ImageSeriesReader. The pixel component type should
+ * of course be a component type supported by the file format.
+ * Output images can be in all file formats ITK supports and for which
+ * the ImageFileReader works, so no dicom output is currently supported.
+ *
+ * authors:       Marius Staring and Stefan Klein
+ *
+ * Thanks to Hans J. Johnson for a modification to this program. This
+ * modification breaks down the program into smaller compilation units,
+ * so that the compiler does not overflow.
+ *
+ */
+
+#include <iostream>
+#include "itkImageFileReader.h"
+
+/** DICOM headers. */
+#include "itkGDCMImageIO.h"
+#include "itkGDCMSeriesFileNames.h"
+
+/** In order to determine if argv[1] is a directory or a file,
+ * so that we can distinguish between dicom and other files.
+ */
+#include <itksys/SystemTools.hxx>
+
+extern int      FileConverterScalar(const std::string &inputPixelComponentType,const std::string &outputPixelComponentType,const std::string &inputFileName, const std::string &outputFileName, int inputDimension);
+extern int DicomFileConverterScalar(const std::string &inputPixelComponentType,const std::string &outputPixelComponentType,const std::string &inputFileName, const std::string &outputFileName, int inputDimension);
+extern int DicomFileConverterScalarA(const std::string &inputPixelComponentType,const std::string &outputPixelComponentType,const std::string &inputFileName, const std::string &outputFileName, int inputDimension);
+
+//-------------------------------------------------------------------------------------
+#include "itkGE4ImageIOFactory.h"
+#include "itkGE5ImageIOFactory.h"
+#include "itkGEAdwImageIOFactory.h"
+
+int  main(  int  argc,  char *argv[] )
+  {
+  itk::GE4ImageIOFactory::RegisterOneFactory();
+  itk::GE5ImageIOFactory::RegisterOneFactory();
+  itk::GEAdwImageIOFactory::RegisterOneFactory();
+
+  /** TASK 1:
+   * Check arguments.
+   * *******************************************************************
+   */
+  if ( argc  < 3 || (strcmp(argv[ 1 ], "--help") == 0) )
+    {
+    std::cout  << "Usage:"  << std::endl;
+    std::cout  << "\tcastconvert inputfilename outputfilename [outputPixelComponentType]" << std::endl;
+    std::cout  << "\tcastconvert dicomDirectory outputfilename [outputPixelComponentType]" << std::endl;
+    std::cout  << "\twhere outputPixelComponentType is one of:" << std::endl;
+    std::cout  << "\t\t- unsigned_char" << std::endl;
+    std::cout  << "\t\t- char" << std::endl;
+    std::cout  << "\t\t- unsigned_short" << std::endl;
+    std::cout  << "\t\t- short" << std::endl;
+    std::cout  << "\t\t- unsigned_int" << std::endl;
+    std::cout  << "\t\t- int" << std::endl;
+    std::cout  << "\t\t- unsigned_long" << std::endl;
+    std::cout  << "\t\t- long" << std::endl;
+    std::cout  << "\t\t- float" << std::endl;
+    std::cout  << "\t\t- double" << std::endl;
+    std::cout  << "\tprovided that the outputPixelComponentType is supported by the output file format." << std::endl;
+    std::cout  << "\tBy default the outputPixelComponentType is set to the inputPixelComponentType." << std::endl;
+    return 1;
+    }
+
+  /**  Get  the  inputs. */
+  std::string  input = argv[ 1 ];
+  std::string outputFileName = argv[ 2 ];
+  std::string outputPixelComponentType = "";
+  if ( argc >= 4 ) outputPixelComponentType = argv[ 3 ];
+
+  /** Make sure last character of input != "/".
+  * Otherwise FileIsDirectory() won't work.
+  */
+  if ( input.rfind( "/" ) == input.size() - 1 )
+    {
+    input.erase( input.size() - 1, 1 );
+    }
+
+  /** Check if input is a file or a directory. */
+  bool exists = itksys::SystemTools::FileExists( input.c_str() );
+  bool isDir = itksys::SystemTools::FileIsDirectory( input.c_str() );
+  bool isVTI = (input.rfind(".vti") == (input.size()-4));
+  bool isDICOM = false;
+  std::string inputFileName, inputDirectoryName;
+
+  if ( exists && !isDir )
+    {
+    /** Input is a file, and we use the ImageFileReader. */
+    inputFileName = input;
+    }
+  else if ( exists && isDir )
+    {
+    /** Input is a directory, and we use the ImageSeriesReader. */
+    inputDirectoryName = input;
+    isDICOM = true;
+    }
+  else
+    {
+    /** Something is wrong. */
+    std::cerr << "ERROR: first input argument does not exist!" << std::endl;
+    return 1;
+    }
+
+  /** Check outputPixelType. */
+  if ( outputPixelComponentType != ""
+    && outputPixelComponentType != "unsigned_char"
+    && outputPixelComponentType != "char"
+    && outputPixelComponentType != "unsigned_short"
+    && outputPixelComponentType != "short"
+    && outputPixelComponentType != "unsigned_int"
+    && outputPixelComponentType != "int"
+    && outputPixelComponentType != "unsigned_long"
+    && outputPixelComponentType != "long"
+    && outputPixelComponentType != "float"
+    && outputPixelComponentType != "double" )
+    {
+    /** In this case an illegal outputPixelComponentType is given. */
+    std::cerr << "The given outputPixelComponentType is \"" << outputPixelComponentType
+      << "\", which is not supported." << std::endl;
+    return 1;
+    }
+
+  /** TASK 2:
+   * Typedefs and test reading to determine correct image types.
+   * *******************************************************************
+   */
+
+  /** Initial image type. */
+  const unsigned int    Dimension  =  3;
+  typedef short         PixelType;
+
+  /** Some typedef's. */
+  typedef itk::Image< PixelType, Dimension >      ImageType;
+  typedef itk::ImageFileReader< ImageType >       ReaderType;
+  typedef itk::ImageIOBase                        ImageIOBaseType;
+  typedef itk::GDCMImageIO                        GDCMImageIOType;
+  typedef itk::GDCMSeriesFileNames                GDCMNamesGeneratorType;
+  typedef std::vector< std::string >              FileNamesContainerType;
+
+  /** Create a testReader. */
+  ReaderType::Pointer testReader = ReaderType::New();
+
+  /** Setup the testReader. */
+  if ( !isDICOM && !isVTI )
+    {
+    /** Set the inputFileName in the testReader. */
+    testReader->SetFileName( inputFileName.c_str() );
+    }
+  else if (!isVTI)
+    {
+    /** Get a name of a 2D image. */
+    GDCMNamesGeneratorType::Pointer nameGenerator = GDCMNamesGeneratorType::New();
+    nameGenerator->SetInputDirectory( inputDirectoryName.c_str() );
+    FileNamesContainerType fileNames = nameGenerator->GetInputFileNames();
+    std::string fileName = fileNames[ 0 ];
+
+    /** Create a dicom ImageIO and set it in the testReader. */
+    GDCMImageIOType::Pointer dicomIO = GDCMImageIOType::New();
+    testReader->SetImageIO( dicomIO );
+
+    /** Set the name of the 2D dicom image in the testReader. */
+    testReader->SetFileName( fileName.c_str() );
+
+    } // end isDICOM
+
+
+  // The defaults are arbitrary. They are computed from GenerateOutputInformation
+  // below. For VTI files, these are computed from the actual input image itself.
+  unsigned int inputDimension = 3;
+  unsigned int numberOfComponents = 1;
+  std::string inputPixelComponentType = "short";
+  std::string pixelType = "scalar";
+
+  /** Get the component type, number of components, dimension and pixel type. */
+  if (!isVTI)
+    {
+    /** Generate all information. */
+    testReader->GenerateOutputInformation();
+
+    /** Extract the ImageIO from the testReader. */
+    ImageIOBaseType::Pointer testImageIOBase = testReader->GetImageIO();
+
+    numberOfComponents = testImageIOBase->GetNumberOfComponents();
+    inputDimension = testImageIOBase->GetNumberOfDimensions();
+    inputPixelComponentType = testImageIOBase->GetComponentTypeAsString(
+      testImageIOBase->GetComponentType() );
+    pixelType = testImageIOBase->GetPixelTypeAsString( testImageIOBase->GetPixelType() );
+    }
+
+  /** TASK 3:
+   * Do some preparations.
+   * *******************************************************************
+   */
+
+  /** Check inputPixelType. */
+  if ( inputPixelComponentType != "unsigned_char"
+    && inputPixelComponentType != "char"
+    && inputPixelComponentType != "unsigned_short"
+    && inputPixelComponentType != "short"
+    && inputPixelComponentType != "unsigned_int"
+    && inputPixelComponentType != "int"
+    && inputPixelComponentType != "unsigned_long"
+    && inputPixelComponentType != "long"
+    && inputPixelComponentType != "float"
+    && inputPixelComponentType != "double" )
+    {
+    /** In this case an illegal inputPixelComponentType is found. */
+    std::cerr << "The found inputPixelComponentType is \"" << inputPixelComponentType
+      << "\", which is not supported." << std::endl;
+    return 1;
+    }
+
+  /** Check outputPixelType. */
+  if ( outputPixelComponentType == "" )
+    {
+    /** In this case this option is not given, and by default
+    * we set it to the inputPixelComponentType.
+    */
+    outputPixelComponentType = inputPixelComponentType;
+    }
+
+  /** Get rid of the "_" in inputPixelComponentType and outputPixelComponentType. */
+  std::basic_string<char>::size_type pos = inputPixelComponentType.find( "_" );
+  static const std::basic_string<char>::size_type npos = std::basic_string<char>::npos;
+  if ( pos != npos )
+    {
+    inputPixelComponentType.replace( pos, 1, " " );
+    }
+  pos = outputPixelComponentType.find( "_" );
+  if ( pos != npos )
+    {
+    outputPixelComponentType.replace( pos, 1, " " );
+    }
+
+  /** TASK 4:
+   * Now we are ready to check on image type and subsequently call the
+   * correct ReadCastWrite-function.
+   * *******************************************************************
+   */
+
+  try
+    {
+    if ( !isDICOM )
+      {
+      /**
+      * ****************** Support for SCALAR pixel types. **********************************
+      */
+      if ( pixelType == "scalar" && numberOfComponents == 1 )
+        {
+        const int ret_value = FileConverterScalar(
+          inputPixelComponentType, outputPixelComponentType, inputFileName,
+          outputFileName, inputDimension );
+        if ( ret_value != 0 )
+          {
+          return ret_value;
+          }
+        }
+      else
+        {
+        std::cerr << "Pixel type is " << pixelType
+          << ", component type is " << inputPixelComponentType
+          << " and number of components equals " << numberOfComponents << "." << std::endl;
+        std::cerr << "ERROR: This image type is not supported." << std::endl;
+        return 1;
+        }
+      } // end NonDicom image
+    else
+      {
+      /** In this case input is a DICOM series, from which we only support
+       * SCALAR pixel types, with component type:
+       * DICOMImageIO2: (unsigned) char, (unsigned) short, float
+       * GDCMImageIO: (unsigned) char, (unsigned) short, (unsigned) int, double
+       * It is also assumed that the dicom series consist of multiple
+       * 2D images forming a 3D image.
+       */
+
+      if ( pixelType == "scalar" && numberOfComponents == 1 )
+        {
+        const int ret_value = DicomFileConverterScalar( 
+          inputPixelComponentType, outputPixelComponentType,
+          inputDirectoryName, outputFileName, inputDimension )
+      ||                  DicomFileConverterScalarA(
+          inputPixelComponentType, outputPixelComponentType,
+          inputDirectoryName, outputFileName, inputDimension );
+        if ( ret_value != 0 )
+          {
+          return ret_value;
+          }
+        }
+      else
+        {
+        std::cerr << "Pixel type is " << pixelType
+          << ", component type is " << inputPixelComponentType
+          << " and number of components equals " << numberOfComponents << "." << std::endl;
+        std::cerr << "ERROR: This DICOM image type is not supported." << std::endl;
+        return 1;
+        }
+      } // end isDICOM
+    } // end try
+  catch( itk::ExceptionObject  &  err  )
+    {
+    /** If any errors have occurred, catch and print the exception and return false. */
+    std::cerr  << "ExceptionObject caught !"  << std::endl;
+    std::cerr  << err <<  std::endl;
+    return 1;
+    }
+
+  /** End  program. Return succes. */
+  return 0;
+
+}  // end main

--- a/ConvertBetweenFileFormats/castconvertConfigure.h.in
+++ b/ConvertBetweenFileFormats/castconvertConfigure.h.in
@@ -1,0 +1,18 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertConfigure.h.in
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
+#cmakedefine USE_VTK

--- a/ConvertBetweenFileFormats/castconvertDicomScalar.cxx
+++ b/ConvertBetweenFileFormats/castconvertDicomScalar.cxx
@@ -1,0 +1,99 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertDicomScalar.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+/** Authors: Marius Staring and Stefan Klein **/
+#include "castconverthelpers.h"
+
+int DicomFileConverterScalar( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputDirectoryName,
+  const std::string &outputFileName, int inputDimension )
+{
+  /** Support for 3D images. */
+  if ( inputDimension == 3 )
+  {
+    /** From unsigned char to something else. */
+    callCorrectReadDicomWriterMacro( unsigned char, unsigned char );
+    callCorrectReadDicomWriterMacro( unsigned char, char );
+    callCorrectReadDicomWriterMacro( unsigned char, unsigned short );
+    callCorrectReadDicomWriterMacro( unsigned char, short );
+    callCorrectReadDicomWriterMacro( unsigned char, unsigned int );
+    callCorrectReadDicomWriterMacro( unsigned char, int );
+    callCorrectReadDicomWriterMacro( unsigned char, unsigned long );
+    callCorrectReadDicomWriterMacro( unsigned char, long );
+    callCorrectReadDicomWriterMacro( unsigned char, float );
+    callCorrectReadDicomWriterMacro( unsigned char, double );
+
+    /** From char to something else. */
+    callCorrectReadDicomWriterMacro( char, unsigned char );
+    callCorrectReadDicomWriterMacro( char, char );
+    callCorrectReadDicomWriterMacro( char, unsigned short );
+    callCorrectReadDicomWriterMacro( char, short );
+    callCorrectReadDicomWriterMacro( char, unsigned int );
+    callCorrectReadDicomWriterMacro( char, int );
+    callCorrectReadDicomWriterMacro( char, unsigned long );
+    callCorrectReadDicomWriterMacro( char, long );
+    callCorrectReadDicomWriterMacro( char, float );
+    callCorrectReadDicomWriterMacro( char, double );
+
+    /** From unsigned short to something else. */
+    callCorrectReadDicomWriterMacro( unsigned short, unsigned char );
+    callCorrectReadDicomWriterMacro( unsigned short, char );
+    callCorrectReadDicomWriterMacro( unsigned short, unsigned short );
+    callCorrectReadDicomWriterMacro( unsigned short, short );
+    callCorrectReadDicomWriterMacro( unsigned short, unsigned int );
+    callCorrectReadDicomWriterMacro( unsigned short, int );
+    callCorrectReadDicomWriterMacro( unsigned short, unsigned long );
+    callCorrectReadDicomWriterMacro( unsigned short, long );
+    callCorrectReadDicomWriterMacro( unsigned short, float );
+    callCorrectReadDicomWriterMacro( unsigned short, double );
+
+    /** From short to something else. */
+    callCorrectReadDicomWriterMacro( short, unsigned char );
+    callCorrectReadDicomWriterMacro( short, char );
+    callCorrectReadDicomWriterMacro( short, unsigned short );
+    callCorrectReadDicomWriterMacro( short, short );
+    callCorrectReadDicomWriterMacro( short, unsigned int );
+    callCorrectReadDicomWriterMacro( short, int );
+    callCorrectReadDicomWriterMacro( short, unsigned long );
+    callCorrectReadDicomWriterMacro( short, long );
+    callCorrectReadDicomWriterMacro( short, float );
+    callCorrectReadDicomWriterMacro( short, double );
+
+    /** From unsigned int to something else. */
+    callCorrectReadDicomWriterMacro( unsigned int, unsigned char );
+    callCorrectReadDicomWriterMacro( unsigned int, char );
+    callCorrectReadDicomWriterMacro( unsigned int, unsigned short );
+    callCorrectReadDicomWriterMacro( unsigned int, short );
+    callCorrectReadDicomWriterMacro( unsigned int, unsigned int );
+    callCorrectReadDicomWriterMacro( unsigned int, int );
+    callCorrectReadDicomWriterMacro( unsigned int, unsigned long );
+    callCorrectReadDicomWriterMacro( unsigned int, long );
+    callCorrectReadDicomWriterMacro( unsigned int, float );
+    callCorrectReadDicomWriterMacro( unsigned int, double );
+
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only 3D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type
+

--- a/ConvertBetweenFileFormats/castconvertDicomScalarA.cxx
+++ b/ConvertBetweenFileFormats/castconvertDicomScalarA.cxx
@@ -1,0 +1,73 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertDicomScalarA.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+/** Authors: Marius Staring and Stefan Klein **/
+#include "castconverthelpers.h"
+
+int DicomFileConverterScalarA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputDirectoryName,
+  const std::string &outputFileName, int inputDimension )
+{
+  /** Support for 3D images. */
+  if ( inputDimension == 3 )
+  {
+    /** From int to something else. */
+    callCorrectReadDicomWriterMacro( int, unsigned char );
+    callCorrectReadDicomWriterMacro( int, char );
+    callCorrectReadDicomWriterMacro( int, unsigned short );
+    callCorrectReadDicomWriterMacro( int, short );
+    callCorrectReadDicomWriterMacro( int, unsigned int );
+    callCorrectReadDicomWriterMacro( int, int );
+    callCorrectReadDicomWriterMacro( int, unsigned long );
+    callCorrectReadDicomWriterMacro( int, long );
+    callCorrectReadDicomWriterMacro( int, float );
+    callCorrectReadDicomWriterMacro( int, double );
+
+    /** From float to something else. */
+    callCorrectReadDicomWriterMacro( float, unsigned char );
+    callCorrectReadDicomWriterMacro( float, char );
+    callCorrectReadDicomWriterMacro( float, unsigned short );
+    callCorrectReadDicomWriterMacro( float, short );
+    callCorrectReadDicomWriterMacro( float, unsigned int );
+    callCorrectReadDicomWriterMacro( float, int );
+    callCorrectReadDicomWriterMacro( float, unsigned long );
+    callCorrectReadDicomWriterMacro( float, long );
+    callCorrectReadDicomWriterMacro( float, float );
+    callCorrectReadDicomWriterMacro( float, double );
+
+    /** From double to something else. */
+    callCorrectReadDicomWriterMacro( double, unsigned char );
+    callCorrectReadDicomWriterMacro( double, char );
+    callCorrectReadDicomWriterMacro( double, unsigned short );
+    callCorrectReadDicomWriterMacro( double, short );
+    callCorrectReadDicomWriterMacro( double, unsigned int );
+    callCorrectReadDicomWriterMacro( double, int );
+    callCorrectReadDicomWriterMacro( double, unsigned long );
+    callCorrectReadDicomWriterMacro( double, long );
+    callCorrectReadDicomWriterMacro( double, float );
+    callCorrectReadDicomWriterMacro( double, double );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only 3D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar.cxx
@@ -1,0 +1,92 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+extern int FileConverterScalar2D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+extern int FileConverterScalar3D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+extern int FileConverterScalar2DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+extern int FileConverterScalar3DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+extern int FileConverterScalar4D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+extern int FileConverterScalar4DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension );
+
+int FileConverterScalar( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  /** Support for 2D images. */
+  if ( inputDimension == 2 )
+  {
+    const int ret_value = FileConverterScalar2D(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension )
+    ||                  FileConverterScalar2DA(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension );
+    if ( ret_value != 0 )
+    {
+      return ret_value;
+    }
+  }
+  else if ( inputDimension == 3 )
+  {
+    const int ret_value = FileConverterScalar3D(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension )
+    ||                  FileConverterScalar3DA(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension );
+    if ( ret_value != 0 )
+    {
+      return ret_value;
+    }
+  } // end support for 3D images
+  else if ( inputDimension == 4 )
+  {
+    const int ret_value = FileConverterScalar4D(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension )
+    ||                  FileConverterScalar4DA(
+      inputPixelComponentType, outputPixelComponentType,
+      inputFileName, outputFileName, inputDimension );
+    if ( ret_value != 0 )
+    {
+      return ret_value;
+    }
+  } // end support for 4D images
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only 2D, 3D, and 4D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a succes value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar2D.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar2D.cxx
@@ -1,0 +1,97 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar2D.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar2D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  enum { ImageDims = 2 };
+
+  if ( inputDimension == ImageDims )
+  {
+    /** From unsigned char to something else. */
+    callCorrectReadWriterMacro( unsigned char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, double, ImageDims );
+
+    /** From char to something else. */
+    callCorrectReadWriterMacro( char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( char, char, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( char, short, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( char, int, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( char, long, ImageDims );
+    callCorrectReadWriterMacro( char, float, ImageDims );
+    callCorrectReadWriterMacro( char, double, ImageDims );
+
+    /** From unsigned short to something else. */
+    callCorrectReadWriterMacro( unsigned short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, double, ImageDims );
+
+    /** From short to something else. */
+    callCorrectReadWriterMacro( short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( short, char, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( short, short, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( short, int, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( short, long, ImageDims );
+    callCorrectReadWriterMacro( short, float, ImageDims );
+    callCorrectReadWriterMacro( short, double, ImageDims );
+
+    /** From unsigned int to something else. */
+    callCorrectReadWriterMacro( unsigned int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, double, ImageDims );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar2DA.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar2DA.cxx
@@ -1,0 +1,97 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar2DA.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar2DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  enum { ImageDims = 2 };
+
+  if ( inputDimension == ImageDims )
+  {
+    /** From int to something else. */
+    callCorrectReadWriterMacro( int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( int, char, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( int, short, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( int, int, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( int, long, ImageDims );
+    callCorrectReadWriterMacro( int, float, ImageDims );
+    callCorrectReadWriterMacro( int, double, ImageDims );
+
+    /** From unsigned long to something else. */
+    callCorrectReadWriterMacro( unsigned long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, double, ImageDims );
+
+    /** From long to something else. */
+    callCorrectReadWriterMacro( long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( long, char, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( long, short, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( long, int, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( long, long, ImageDims );
+    callCorrectReadWriterMacro( long, float, ImageDims );
+    callCorrectReadWriterMacro( long, double, ImageDims );
+
+    /** From float to something else. */
+    callCorrectReadWriterMacro( float, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( float, char, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( float, short, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( float, int, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( float, long, ImageDims );
+    callCorrectReadWriterMacro( float, float, ImageDims );
+    callCorrectReadWriterMacro( float, double, ImageDims );
+
+    /** From double to something else. */
+    callCorrectReadWriterMacro( double, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( double, char, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( double, short, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( double, int, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( double, long, ImageDims );
+    callCorrectReadWriterMacro( double, float, ImageDims );
+    callCorrectReadWriterMacro( double, double, ImageDims );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar3D.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar3D.cxx
@@ -1,0 +1,97 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar3D.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar3D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  enum { ImageDims = 3 };
+
+  if ( inputDimension == ImageDims )
+  {
+    /** From unsigned char to something else. */
+    callCorrectReadWriterMacro( unsigned char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, double, ImageDims );
+
+    /** From char to something else. */
+    callCorrectReadWriterMacro( char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( char, char, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( char, short, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( char, int, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( char, long, ImageDims );
+    callCorrectReadWriterMacro( char, float, ImageDims );
+    callCorrectReadWriterMacro( char, double, ImageDims );
+
+    /** From unsigned short to something else. */
+    callCorrectReadWriterMacro( unsigned short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, double, ImageDims );
+
+    /** From short to something else. */
+    callCorrectReadWriterMacro( short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( short, char, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( short, short, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( short, int, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( short, long, ImageDims );
+    callCorrectReadWriterMacro( short, float, ImageDims );
+    callCorrectReadWriterMacro( short, double, ImageDims );
+
+    /** From unsigned int to something else. */
+    callCorrectReadWriterMacro( unsigned int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, double, ImageDims );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar3DA.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar3DA.cxx
@@ -1,0 +1,98 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar3DA.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar3DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  enum { ImageDims = 3 };
+
+  if ( inputDimension == ImageDims )
+  {
+    /** From int to something else. */
+    callCorrectReadWriterMacro( int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( int, char, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( int, short, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( int, int, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( int, long, ImageDims );
+    callCorrectReadWriterMacro( int, float, ImageDims );
+    callCorrectReadWriterMacro( int, double, ImageDims );
+
+    /** From unsigned long to something else. */
+    callCorrectReadWriterMacro( unsigned long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, double, ImageDims );
+
+    /** From long to something else. */
+    callCorrectReadWriterMacro( long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( long, char, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( long, short, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( long, int, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( long, long, ImageDims );
+    callCorrectReadWriterMacro( long, float, ImageDims );
+    callCorrectReadWriterMacro( long, double, ImageDims );
+
+    /** From float to something else. */
+    callCorrectReadWriterMacro( float, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( float, char, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( float, short, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( float, int, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( float, long, ImageDims );
+    callCorrectReadWriterMacro( float, float, ImageDims );
+    callCorrectReadWriterMacro( float, double, ImageDims );
+
+    /** From double to something else. */
+    callCorrectReadWriterMacro( double, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( double, char, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( double, short, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( double, int, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( double, long, ImageDims );
+    callCorrectReadWriterMacro( double, float, ImageDims );
+    callCorrectReadWriterMacro( double, double, ImageDims );
+
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar4D.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar4D.cxx
@@ -1,0 +1,97 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar4D.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar4D( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+ 
+  enum { ImageDims = 4 };
+  
+  if ( inputDimension == ImageDims )
+  {
+    callCorrectReadWriterMacro( int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( int, char, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( int, short, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( int, int, ImageDims );
+    callCorrectReadWriterMacro( int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( int, long, ImageDims );
+    callCorrectReadWriterMacro( int, float, ImageDims );
+    callCorrectReadWriterMacro( int, double, ImageDims );
+
+
+    callCorrectReadWriterMacro( unsigned long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned long, double, ImageDims );
+
+
+    callCorrectReadWriterMacro( long, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( long, char, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( long, short, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( long, int, ImageDims );
+    callCorrectReadWriterMacro( long, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( long, long, ImageDims );
+    callCorrectReadWriterMacro( long, float, ImageDims );
+    callCorrectReadWriterMacro( long, double, ImageDims );
+
+
+    callCorrectReadWriterMacro( float, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( float, char, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( float, short, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( float, int, ImageDims );
+    callCorrectReadWriterMacro( float, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( float, long, ImageDims );
+    callCorrectReadWriterMacro( float, float, ImageDims );
+    callCorrectReadWriterMacro( float, double, ImageDims );
+
+
+    callCorrectReadWriterMacro( double, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( double, char, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( double, short, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( double, int, ImageDims );
+    callCorrectReadWriterMacro( double, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( double, long, ImageDims );
+    callCorrectReadWriterMacro( double, float, ImageDims );
+    callCorrectReadWriterMacro( double, double, ImageDims );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type

--- a/ConvertBetweenFileFormats/castconvertScalar4DA.cxx
+++ b/ConvertBetweenFileFormats/castconvertScalar4DA.cxx
@@ -1,0 +1,94 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconvertScalar4DA.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "castconverthelpers.h"
+
+int FileConverterScalar4DA( const std::string &inputPixelComponentType,
+  const std::string &outputPixelComponentType, const std::string &inputFileName,
+  const std::string &outputFileName, int inputDimension )
+{
+  enum { ImageDims = 4 };
+  
+  if ( inputDimension == ImageDims )
+  {
+    /** From unsigned char to something else. */
+    callCorrectReadWriterMacro( unsigned char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned char, double, ImageDims );
+
+    callCorrectReadWriterMacro( char, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( char, char, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( char, short, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( char, int, ImageDims );
+    callCorrectReadWriterMacro( char, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( char, long, ImageDims );
+    callCorrectReadWriterMacro( char, float, ImageDims );
+    callCorrectReadWriterMacro( char, double, ImageDims );
+ 
+    callCorrectReadWriterMacro( unsigned short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned short, double, ImageDims );
+
+    callCorrectReadWriterMacro( short, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( short, char, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( short, short, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( short, int, ImageDims );
+    callCorrectReadWriterMacro( short, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( short, long, ImageDims );
+    callCorrectReadWriterMacro( short, float, ImageDims );
+    callCorrectReadWriterMacro( short, double, ImageDims );
+
+    callCorrectReadWriterMacro( unsigned int, unsigned char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, char, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, short, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, int, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, unsigned long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, long, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, float, ImageDims );
+    callCorrectReadWriterMacro( unsigned int, double, ImageDims );
+  }
+  else
+  {
+    std::cerr << "Dimension equals " << inputDimension << ", which is not supported." << std::endl;
+    std::cerr << "Only "<< ImageDims << "D images are supported." << std::endl;
+    return 1;
+  } // end if over inputDimension
+
+  /** Return a value. */
+  return 0;
+
+} // end support for SCALAR pixel type
+

--- a/ConvertBetweenFileFormats/castconverthelpers.h
+++ b/ConvertBetweenFileFormats/castconverthelpers.h
@@ -1,0 +1,380 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    castconverthelpers.h
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) 2002 Insight Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#ifndef __castconverthelpers_h__
+#define __castconverthelpers_h__
+
+#include "castconvertConfigure.h"
+
+/** Basic Image support. */
+#include "itkImage.h"
+#include "itkImageIORegion.h"
+
+/** For the support of RGB voxels. */
+//#include "itkRGBPixel.h"
+
+/** Reading and writing images. */
+#include "itkImageFileReader.h"
+#include "itkImageSeriesReader.h"
+#include "itkImageFileWriter.h"
+#include "itkImageRegionConstIterator.h"
+
+/** DICOM headers. */
+#include "itkGDCMImageIO.h"
+#include "itkGDCMSeriesFileNames.h"
+
+/** One of these is used to cast the image. */
+#include "itkShiftScaleImageFilter.h"
+#include "itkRescaleIntensityImageFilter.h"
+
+#ifdef VTK_FOUND
+#include "itkImageToVTKImageFilter.h"
+#include "itkVTKImageToImageFilter.h"
+#include "vtkSmartPointer.h"
+#include "vtkImageData.h"
+#include "vtkXMLImageDataWriter.h"
+#include "vtkXMLImageDataReader.h"
+#include "vtkMetaImageWriter.h"
+#include "vtkPointData.h"
+#include "vtkDataArray.h"
+#endif
+
+/** Print image information from the reader and the writer. */
+template< class ReaderType, class WriterType >
+void PrintInfo( ReaderType reader, WriterType writer )
+{
+  /** Typedef's. */
+  typedef itk::ImageIOBase                        ImageIOBaseType;
+  typedef itk::ImageIORegion                      ImageIORegionType;
+  typedef typename ImageIORegionType::SizeType    SizeType;
+
+  /** Get IOBase of the reader and extract information. */
+  ImageIOBaseType::Pointer imageIOBaseIn = reader->GetImageIO();
+  ImageIORegionType iORegionIn = imageIOBaseIn->GetIORegion();
+
+  const char * fileNameIn = imageIOBaseIn->GetFileName();
+  std::string pixelTypeIn = imageIOBaseIn->GetPixelTypeAsString( imageIOBaseIn->GetPixelType() );
+  unsigned int nocIn = imageIOBaseIn->GetNumberOfComponents();
+  std::string componentTypeIn = imageIOBaseIn->GetComponentTypeAsString( imageIOBaseIn->GetComponentType() );
+  unsigned int dimensionIn = imageIOBaseIn->GetNumberOfDimensions();
+  SizeType sizeIn = iORegionIn.GetSize();
+
+  /**  Get  IOBase of  the  writer and extract information.  */
+  ImageIOBaseType::Pointer imageIOBaseOut = writer->GetImageIO();
+  ImageIORegionType iORegionOut = imageIOBaseOut->GetIORegion();
+
+  const char * fileNameOut = imageIOBaseOut->GetFileName();
+  std::string pixelTypeOut = imageIOBaseOut->GetPixelTypeAsString( imageIOBaseOut->GetPixelType() );
+  unsigned int nocOut = imageIOBaseOut->GetNumberOfComponents();
+  std::string componentTypeOut = imageIOBaseOut->GetComponentTypeAsString( imageIOBaseOut->GetComponentType() );
+  unsigned int dimensionOut = imageIOBaseOut->GetNumberOfDimensions();
+  SizeType sizeOut = iORegionOut.GetSize();
+
+  /** Print information. */
+  std::cout << "Information about the input image \"" << fileNameIn << "\":" << std::endl;
+  std::cout << "\tdimension:\t\t" << dimensionIn << std::endl;
+  std::cout << "\tpixel type:\t\t" << pixelTypeIn << std::endl;
+  std::cout << "\tnumber of components:\t" << nocIn << std::endl;
+  std::cout << "\tcomponent type:\t\t" << componentTypeIn << std::endl;
+  std::cout << "\tsize:\t\t\t";
+  for ( unsigned int i = 0; i < dimensionIn; i++ ) std::cout << sizeIn[ i ] << " ";
+  std::cout << std::endl;
+
+  /** Print information. */
+  std::cout << std::endl;
+  std::cout << "Information about the output image \"" << fileNameOut << "\":" << std::endl;
+  std::cout << "\tdimension:\t\t" << dimensionOut << std::endl;
+  std::cout << "\tpixel type:\t\t" << pixelTypeOut << std::endl;
+  std::cout << "\tnumber of components:\t" << nocOut << std::endl;
+  std::cout << "\tcomponent type:\t\t" << componentTypeOut << std::endl;
+  std::cout << "\tsize:\t\t\t";
+  for ( unsigned int i = 0; i < dimensionOut; i++ ) std::cout << sizeOut[ i ] << " ";
+  std::cout << std::endl;
+
+}  // end PrintInfo
+
+/** The function that reads the input dicom image and writes the output image.
+ * This function is templated over the image types. In the main function
+ * we have to make sure to call the right instantiation.
+ */
+template< class InputImageType, class OutputImageType >
+void ReadDicomSeriesCastWriteImage( std::string inputDirectoryName, std::string  outputFileName )
+{
+  /** Typedef the correct reader, caster and writer. */
+  typedef typename itk::ImageSeriesReader< InputImageType >     SeriesReaderType;
+  typedef typename itk::RescaleIntensityImageFilter<
+    InputImageType, OutputImageType >                           RescaleFilterType;
+  typedef typename itk::ShiftScaleImageFilter<
+    InputImageType, OutputImageType >                           ShiftScaleFilterType;
+  typedef typename itk::ImageFileWriter< OutputImageType >      ImageWriterType;
+
+  /** Typedef dicom stuff. */
+  typedef itk::GDCMImageIO                  GDCMImageIOType;
+  typedef itk::GDCMSeriesFileNames          GDCMNamesGeneratorType;
+  typedef std::vector< std::string >        FileNamesContainerType;
+
+  /** Create the dicom ImageIO. */
+  typename GDCMImageIOType::Pointer dicomIO = GDCMImageIOType::New();
+
+  /** Get a list of the filenames of the 2D input dicom images. */
+  GDCMNamesGeneratorType::Pointer nameGenerator = GDCMNamesGeneratorType::New();
+  nameGenerator->SetInputDirectory( inputDirectoryName.c_str() );
+  FileNamesContainerType fileNames = nameGenerator->GetInputFileNames();
+
+  /** Create and setup the seriesReader. */
+  typename SeriesReaderType::Pointer seriesReader = SeriesReaderType::New();
+  seriesReader->SetFileNames( fileNames );
+  seriesReader->SetImageIO( dicomIO );
+
+  /** Create and setup caster and writer. */
+  //typename RescaleFilterType::Pointer caster = RescaleFilterType::New();
+  typename ShiftScaleFilterType::Pointer caster = ShiftScaleFilterType::New();
+  typename ImageWriterType::Pointer  writer = ImageWriterType::New();
+  caster->SetShift( 0.0 );
+  caster->SetScale( 1.0 );
+  writer->SetFileName( outputFileName.c_str()  );
+
+  /** Connect the pipeline. */
+  caster->SetInput(  seriesReader->GetOutput()  );
+  writer->SetInput(  caster->GetOutput()  );
+  writer->UseCompressionOn();
+
+  // Handle .vti files as well.
+#ifdef VTK_FOUND
+  if (outputFileName.rfind(".vti") == (outputFileName.size()-4))
+    {
+    typedef itk::ImageToVTKImageFilter< OutputImageType > ITKToVTKFilterType;
+    typename ITKToVTKFilterType::Pointer itktovtk = ITKToVTKFilterType::New();
+    caster->Update();
+    itktovtk->SetInput( caster->GetOutput() );
+    itktovtk->Update();
+    
+    vtkSmartPointer< vtkXMLImageDataWriter > writer_vti 
+      = vtkSmartPointer< vtkXMLImageDataWriter >::New();
+    writer_vti->SetFileName(outputFileName.c_str());
+    writer_vti->SetInput( itktovtk->GetOutput() );
+
+    // necessary to give the data array a name others reading it fails !!
+    itktovtk->GetOutput()->GetPointData()->GetScalars()->SetName("Scalars_");
+    
+    writer_vti->Write();
+    std::cout << "Wrote: " << outputFileName << std::endl;
+    return;
+    }
+#endif
+
+  /**  Do the actual  conversion.  */
+  writer->Update();
+
+  /**  Print  information. */
+  PrintInfo( seriesReader, writer );
+
+}  // end ReadDicomSeriesCastWriteImage
+
+
+/** The function that reads the input image and writes the output image.
+ * This function is templated over the image types. In the main function
+ * we have to make sure to call the right instantiation.
+ */
+template< class InputImageType, class OutputImageType >
+void ReadCastWriteImage( std::string inputFileName, std::string outputFileName )
+{
+  /**  Typedef the correct reader, caster and writer. */
+  typedef typename itk::ImageFileReader< InputImageType >     ImageReaderType;
+  typedef typename itk::RescaleIntensityImageFilter<
+    InputImageType, OutputImageType >                         RescaleFilterType;
+  typedef typename itk::ShiftScaleImageFilter<
+    InputImageType, OutputImageType >                         ShiftScaleFilterType;
+  typedef typename itk::ImageFileWriter< OutputImageType >    ImageWriterType;
+#ifdef VTK_FOUND
+  typedef itk::VTKImageToImageFilter< InputImageType > VTKToITKFilterType;
+  typename VTKToITKFilterType::Pointer vtktoitk = NULL;
+#endif
+  typename ImageReaderType::Pointer reader = ImageReaderType::New();
+  typename ShiftScaleFilterType::Pointer caster = ShiftScaleFilterType::New();
+  typename ImageWriterType::Pointer  writer = ImageWriterType::New();
+  caster->SetShift( 0.0 );
+  caster->SetScale( 1.0 );
+
+  /** Create and setup the reader. */
+  reader->SetFileName( inputFileName.c_str() );
+
+
+#ifdef VTK_FOUND
+  if (inputFileName.rfind(".vti") == (inputFileName.size()-4))
+    {
+    // Handle .vti files as well.
+    vtkSmartPointer< vtkXMLImageDataReader > reader_vti 
+      = vtkSmartPointer< vtkXMLImageDataReader >::New();
+    reader_vti->SetFileName(inputFileName.c_str());
+    reader_vti->Update();
+    std::cout << "Read: " << inputFileName << std::endl;
+
+    vtktoitk = VTKToITKFilterType::New();
+    vtktoitk->SetInput( reader_vti->GetOutput() );
+    vtktoitk->Update();
+    caster->SetInput(vtktoitk->GetOutput());
+    }
+  else
+    {
+#endif
+  
+  //typename RescaleFilterType::Pointer caster = RescaleFilterType::New();
+  caster->SetInput( reader->GetOutput() );
+
+#ifdef VTK_FOUND
+    }
+
+  if (outputFileName.rfind(".vti") == (outputFileName.size()-4))
+    {
+    // Handle .vti files as well.
+    typedef itk::ImageToVTKImageFilter< OutputImageType > ITKToVTKFilterType;
+    typename ITKToVTKFilterType::Pointer itktovtk = ITKToVTKFilterType::New();
+    caster->Update();
+    itktovtk->SetInput( caster->GetOutput() );
+    itktovtk->Update();
+    
+    vtkSmartPointer< vtkXMLImageDataWriter > writer_vti 
+      = vtkSmartPointer< vtkXMLImageDataWriter >::New();
+    writer_vti->SetFileName(outputFileName.c_str());
+    writer_vti->SetInput( itktovtk->GetOutput() );
+
+    // necessary to give the data array a name others reading it fails !!
+    itktovtk->GetOutput()->GetPointData()->GetScalars()->SetName("Scalars_");
+
+    writer_vti->Write();
+    std::cout << "Wrote: " << outputFileName << std::endl;
+    return;
+    }
+#endif
+
+  writer->UseCompressionOn();
+  writer->SetFileName( outputFileName.c_str()  );
+  writer->SetInput( caster->GetOutput() );
+  writer->Update();
+
+  if (inputFileName.rfind(".vti") != (inputFileName.size()-4))
+    {
+    /** Print information. */
+    PrintInfo( reader, writer );
+    }
+
+}  // end ReadWriteImage
+
+
+// Read VTI files and write out ITK/VTI images. We have some templated macros
+// to deal with since VTK does not have templated images while ITK does.
+#ifdef VTK_FOUND
+
+// ITK's support for 64 bit types, long long etc is poor, not as exhaustive
+// as VTK. Define an alternate macro here that ignores those types. Nobody
+// will use them anyway.
+#define vtkitkTemplateMacro(call)                                           \
+  vtkTemplateMacroCase(VTK_DOUBLE, double, call);                           \
+  vtkTemplateMacroCase(VTK_FLOAT, float, call);                             \
+  vtkTemplateMacroCase(VTK_LONG, long, call);                               \
+  vtkTemplateMacroCase(VTK_UNSIGNED_LONG, unsigned long, call);             \
+  vtkTemplateMacroCase(VTK_INT, int, call);                                 \
+  vtkTemplateMacroCase(VTK_UNSIGNED_INT, unsigned int, call);               \
+  vtkTemplateMacroCase(VTK_SHORT, short, call);                             \
+  vtkTemplateMacroCase(VTK_UNSIGNED_SHORT, unsigned short, call);           \
+  vtkTemplateMacroCase(VTK_CHAR, char, call);                               \
+  vtkTemplateMacroCase(VTK_SIGNED_CHAR, signed char, call);                 \
+  vtkTemplateMacroCase(VTK_UNSIGNED_CHAR, unsigned char, call)
+
+template< class TInputPixelType, class TOutputPixelType > int
+ReadVTICastWriteImage( std::string inputFileName, 
+                       std::string outputFileName, 
+                       TInputPixelType, TOutputPixelType )
+{
+  typedef itk::Image< TInputPixelType,  3 > InputImageType;
+  typedef itk::Image< TOutputPixelType, 3 > OutputImageType;
+  ReadCastWriteImage< InputImageType, OutputImageType >( 
+                         inputFileName, outputFileName );
+  return 1;
+}
+
+template< class TOutputPixelType > int
+ReadVTICastWriteImage( std::string inputFileName, 
+                       std::string outputFileName, 
+                       int dimension )
+{
+  int retval = 0;
+  if (inputFileName.rfind(".vti") == (inputFileName.size()-4) && dimension == 3)
+    {
+    vtkSmartPointer< vtkXMLImageDataReader > reader =
+      vtkSmartPointer< vtkXMLImageDataReader >::New();
+    reader->SetFileName( inputFileName.c_str() );
+    reader->Update();
+    vtkImageData *image = reader->GetOutput();
+    TOutputPixelType op = static_cast< TOutputPixelType >(0);
+    switch (image->GetScalarType())
+      {
+      vtkitkTemplateMacro( retval =  
+          ReadVTICastWriteImage( inputFileName, outputFileName, static_cast< VTK_TT >(0), op ));      
+      
+      default:
+        {
+        std::cout << "VTI conversion.. Unknown scalar type" << std::endl;
+        break;
+        }
+      }
+    }
+
+  return retval;
+}
+#else
+template< class TOuptutPixelType > int
+ReadVTICastWriteImage( std::string inputFileName, 
+                       std::string outputFileName, 
+                       int dimension )
+{
+  return 0;
+}
+#endif
+
+
+/** Macros are used in order to make the code in main() look cleaner. */
+
+/** callCorrectReadDicomWriterMacro:
+ * A macro to call the dicom-conversion function.
+ */
+
+#define callCorrectReadDicomWriterMacro(typeIn,typeOut) \
+    if ( inputPixelComponentType == #typeIn && outputPixelComponentType == #typeOut ) \
+{ \
+    typedef  itk::Image< typeIn, 3 >    InputImageType; \
+    typedef  itk::Image< typeOut, 3 >  OutputImageType; \
+    ReadDicomSeriesCastWriteImage< InputImageType, OutputImageType >( inputDirectoryName, outputFileName ); \
+}
+
+/** callCorrectReadWriterMacro:
+ * A macro to call the conversion function.
+ */
+
+#define callCorrectReadWriterMacro(typeIn,typeOut,dim) \
+    if ( inputPixelComponentType == #typeIn && outputPixelComponentType == #typeOut && inputDimension == dim) \
+{ \
+    if (!ReadVTICastWriteImage< typeOut >( inputFileName, outputFileName, dim )) \
+      { \
+      typedef  itk::Image< typeIn, dim >    InputImageType; \
+      typedef  itk::Image< typeOut, dim >  OutputImageType; \
+      ReadCastWriteImage< InputImageType, OutputImageType >( inputFileName, outputFileName ); \
+      } \
+}
+
+
+#endif //__castconverthelpers_h__

--- a/ConvertBetweenFileFormats/itkTestMain.h
+++ b/ConvertBetweenFileFormats/itkTestMain.h
@@ -1,0 +1,516 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+/*=========================================================================
+ *
+ *  Portions of this file are subject to the VTK Toolkit Version 3 copyright.
+ *
+ *  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+ *
+ *  For complete copyright, license and disclaimer of warranty information
+ *  please refer to the NOTICE file at the top of the ITK source tree.
+ *
+ *=========================================================================*/
+#ifndef __itkTestMain_h
+#define __itkTestMain_h
+
+// This file is used to create TestDriver executables
+// These executables are able to register a function pointer to a string name
+// in a lookup table.   By including this file, it creates a main function
+// that calls RegisterTests() then looks up the function pointer for the test
+// specified on the command line.
+#include "itkMacro.h"
+#include <map>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include "itkMultiThreader.h"
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkSubtractImageFilter.h"
+#include "itkRescaleIntensityImageFilter.h"
+#include "itkExtractImageFilter.h"
+#if ITK_VERSION_MAJOR < 4
+#include "itkDifferenceImageFilter.h"
+#else
+#include "itkTestingComparisonImageFilter.h"
+#endif
+#include "itksys/SystemTools.hxx"
+#include "itkIntTypes.h"
+#include "itkFloatingPointExceptions.h"
+
+#define ITK_TEST_DIMENSION_MAX 6
+
+typedef int ( *MainFuncPointer )(int, char *[]);
+std::map< std::string, MainFuncPointer > StringToTestFunctionMap;
+
+#define REGISTER_TEST(test)       \
+  extern int test(int, char *[]); \
+  StringToTestFunctionMap[#test] = test
+
+int RegressionTestImage(const char *testImageFilename,
+                        const char *baselineImageFilename,
+                        int reportErrors,
+                        double intensityTolerance,
+                        ::itk::SizeValueType numberOfPixelsTolerance = 0,
+                        unsigned int radiusTolerance = 0);
+
+std::map< std::string, int > RegressionTestBaselines(char *);
+
+void RegisterTests();
+
+void PrintAvailableTests()
+{
+  std::cout << "Available tests:\n";
+  std::map< std::string, MainFuncPointer >::iterator j = StringToTestFunctionMap.begin();
+  int                                                i = 0;
+  while ( j != StringToTestFunctionMap.end() )
+    {
+    std::cout << i << ". " << j->first << "\n";
+    ++i;
+    ++j;
+    }
+}
+
+int main(int ac, char *av[])
+{
+  itk::FloatingPointExceptions::Enable();
+
+  double intensityTolerance  = 2.0;
+  unsigned int numberOfPixelsTolerance = 0;
+  unsigned int radiusTolerance = 0;
+
+  typedef std::pair< char *, char * > ComparePairType;
+  std::vector< ComparePairType > compareList;
+
+  RegisterTests();
+  std::string testToRun;
+  if ( ac < 2 )
+    {
+    PrintAvailableTests();
+    std::cout << "To run a test, enter the test number: ";
+    int testNum = 0;
+    std::cin >> testNum;
+    std::map< std::string, MainFuncPointer >::iterator j = StringToTestFunctionMap.begin();
+    int                                                i = 0;
+    while ( j != StringToTestFunctionMap.end() && i < testNum )
+      {
+      ++i;
+      ++j;
+      }
+    if ( j == StringToTestFunctionMap.end() )
+      {
+      std::cerr << testNum << " is an invalid test number\n";
+      return -1;
+      }
+    testToRun = j->first;
+    }
+  else
+    {
+    while ( ac > 0 && testToRun.empty() )
+      {
+      if ( strcmp(av[1], "--with-threads") == 0 )
+        {
+        int numThreads = atoi(av[2]);
+        itk::MultiThreader::SetGlobalDefaultNumberOfThreads(numThreads);
+        av += 2;
+        ac -= 2;
+        }
+      else if ( strcmp(av[1], "--without-threads") == 0 )
+        {
+        itk::MultiThreader::SetGlobalDefaultNumberOfThreads(1);
+        av += 1;
+        ac -= 1;
+        }
+      else if ( ac > 3 && strcmp(av[1], "--compare") == 0 )
+        {
+        compareList.push_back( ComparePairType(av[2], av[3]) );
+        av += 3;
+        ac -= 3;
+        }
+      else if ( ac > 2 && strcmp(av[1], "--compareNumberOfPixelsTolerance") == 0 )
+        {
+        numberOfPixelsTolerance = atoi(av[2]);
+        av += 2;
+        ac -= 2;
+        }
+      else if ( ac > 2 && strcmp(av[1], "--compareRadiusTolerance") == 0 )
+        {
+        radiusTolerance = atoi(av[2]);
+        av += 2;
+        ac -= 2;
+        }
+      else if ( ac > 2 && strcmp(av[1], "--compareIntensityTolerance") == 0 )
+        {
+        intensityTolerance = atof(av[2]);
+        av += 2;
+        ac -= 2;
+        }
+      else
+        {
+        testToRun = av[1];
+        }
+      }
+    }
+  std::map< std::string, MainFuncPointer >::iterator j = StringToTestFunctionMap.find(testToRun);
+  if ( j != StringToTestFunctionMap.end() )
+    {
+    MainFuncPointer f = j->second;
+    int             result;
+    try
+      {
+      // Invoke the test's "main" function.
+      result = ( *f )( ac - 1, av + 1 );
+
+      // Make a list of possible baselines
+      for ( int i = 0; i < static_cast< int >( compareList.size() ); i++ )
+        {
+        char *                                 baselineFilename = compareList[i].first;
+        char *                                 testFilename = compareList[i].second;
+        std::map< std::string, int >           baselines = RegressionTestBaselines(baselineFilename);
+        std::map< std::string, int >::iterator baseline = baselines.begin();
+        std::string                            bestBaseline;
+        int                                    bestBaselineStatus = itk::NumericTraits< int >::max();
+        while ( baseline != baselines.end() )
+          {
+          baseline->second = RegressionTestImage(testFilename,
+                                                 ( baseline->first ).c_str(),
+                                                 0,
+                                                 intensityTolerance,
+                                                 numberOfPixelsTolerance,
+                                                 radiusTolerance);
+          if ( baseline->second < bestBaselineStatus )
+            {
+            bestBaseline = baseline->first;
+            bestBaselineStatus = baseline->second;
+            }
+          if ( baseline->second == 0 )
+            {
+            break;
+            }
+          ++baseline;
+          }
+        // if the best we can do still has errors, generate the error images
+        if ( bestBaselineStatus )
+          {
+          RegressionTestImage(testFilename,
+                              bestBaseline.c_str(),
+                              1,
+                              intensityTolerance,
+                              numberOfPixelsTolerance,
+                              radiusTolerance);
+          }
+
+        // output the matching baseline
+        std::cout << "<DartMeasurement name=\"BaselineImageName\" type=\"text/string\">";
+        std::cout << itksys::SystemTools::GetFilenameName(bestBaseline);
+        std::cout << "</DartMeasurement>" << std::endl;
+
+        result += bestBaselineStatus;
+        }
+      }
+    catch ( const itk::ExceptionObject & e )
+      {
+      std::cerr << "ITK test driver caught an ITK exception:\n";
+      e.Print(std::cerr);
+      result = -1;
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "ITK test driver caught an exception:\n";
+      std::cerr << e.what() << "\n";
+      result = -1;
+      }
+    catch ( ... )
+      {
+      std::cerr << "ITK test driver caught an unknown exception!!!\n";
+      result = -1;
+      }
+    return result;
+    }
+  PrintAvailableTests();
+  std::cerr << "Failed: " << testToRun << ": No test registered with name " << testToRun << "\n";
+  return -1;
+}
+
+// Regression Testing Code
+
+int RegressionTestImage(const char *testImageFilename,
+                        const char *baselineImageFilename,
+                        int reportErrors,
+                        double intensityTolerance,
+                        ::itk::SizeValueType numberOfPixelsTolerance,
+                        unsigned int radiusTolerance)
+{
+  // Use the factory mechanism to read the test and baseline files and convert
+  // them to double
+  typedef itk::Image< double, ITK_TEST_DIMENSION_MAX >        ImageType;
+  typedef itk::Image< unsigned char, ITK_TEST_DIMENSION_MAX > OutputType;
+  typedef itk::Image< unsigned char, 2 >                      DiffOutputType;
+  typedef itk::ImageFileReader< ImageType >                   ReaderType;
+
+  // Read the baseline file
+  ReaderType::Pointer baselineReader = ReaderType::New();
+  baselineReader->SetFileName(baselineImageFilename);
+  try
+    {
+    baselineReader->UpdateLargestPossibleRegion();
+    }
+  catch ( itk::ExceptionObject & e )
+    {
+    std::cerr << "Exception detected while reading " << baselineImageFilename << " : "  << e.GetDescription();
+    return 1000;
+    }
+
+  // Read the file generated by the test
+  ReaderType::Pointer testReader = ReaderType::New();
+  testReader->SetFileName(testImageFilename);
+  try
+    {
+    testReader->UpdateLargestPossibleRegion();
+    }
+  catch ( itk::ExceptionObject & e )
+    {
+    std::cerr << "Exception detected while reading " << testImageFilename << " : "  << e.GetDescription() << std::endl;
+    return 1000;
+    }
+
+  // The sizes of the baseline and test image must match
+  ImageType::SizeType baselineSize;
+  baselineSize = baselineReader->GetOutput()->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType testSize;
+  testSize = testReader->GetOutput()->GetLargestPossibleRegion().GetSize();
+
+  if ( baselineSize != testSize )
+    {
+    std::cerr << "The size of the Baseline image and Test image do not match!" << std::endl;
+    std::cerr << "Baseline image: " << baselineImageFilename
+              << " has size " << baselineSize << std::endl;
+    std::cerr << "Test image:     " << testImageFilename
+              << " has size " << testSize << std::endl;
+    return 1;
+    }
+
+  // Now compare the two images
+#if ITK_VERSION_MAJOR < 4
+  typedef itk::DifferenceImageFilter< ImageType, ImageType > DiffType;
+#else
+  typedef itk::Testing::ComparisonImageFilter< ImageType, ImageType > DiffType;
+#endif
+  DiffType::Pointer diff = DiffType::New();
+  diff->SetValidInput( baselineReader->GetOutput() );
+  diff->SetTestInput( testReader->GetOutput() );
+  diff->SetDifferenceThreshold(intensityTolerance);
+  diff->SetToleranceRadius(radiusTolerance);
+  diff->UpdateLargestPossibleRegion();
+
+  itk::SizeValueType status = itk::NumericTraits< itk::SizeValueType >::Zero;
+  status = diff->GetNumberOfPixelsWithDifferences();
+
+  // if there are discrepencies, create an diff image
+  if ( ( status > numberOfPixelsTolerance ) && reportErrors )
+    {
+    typedef itk::RescaleIntensityImageFilter< ImageType, OutputType > RescaleType;
+    typedef itk::ExtractImageFilter< OutputType, DiffOutputType >     ExtractType;
+    typedef itk::ImageFileWriter< DiffOutputType >                    WriterType;
+    typedef itk::ImageRegion< ITK_TEST_DIMENSION_MAX >                RegionType;
+    OutputType::SizeType size; size.Fill(0);
+
+    RescaleType::Pointer rescale = RescaleType::New();
+    rescale->SetOutputMinimum( itk::NumericTraits< unsigned char >::NonpositiveMin() );
+    rescale->SetOutputMaximum( itk::NumericTraits< unsigned char >::max() );
+    rescale->SetInput( diff->GetOutput() );
+    rescale->UpdateLargestPossibleRegion();
+    size = rescale->GetOutput()->GetLargestPossibleRegion().GetSize();
+
+    //Get the center slice of the image,  In 3D, the first slice
+    //is often a black slice with little debugging information.
+    OutputType::IndexType index; index.Fill(0);
+    for ( unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; i++ )
+      {
+      index[i] = size[i] / 2; //NOTE: Integer Divide used to get approximately
+                              // the center slice
+      size[i] = 0;
+      }
+
+    RegionType region;
+    region.SetIndex(index);
+
+    region.SetSize(size);
+
+    ExtractType::Pointer extract = ExtractType::New();
+    extract->SetDirectionCollapseToSubmatrix();
+    extract->SetInput( rescale->GetOutput() );
+    extract->SetExtractionRegion(region);
+
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetInput( extract->GetOutput() );
+
+    std::cout << "<DartMeasurement name=\"ImageError\" type=\"numeric/double\">";
+    std::cout << status;
+    std::cout <<  "</DartMeasurement>" << std::endl;
+
+    std::ostringstream diffName;
+    diffName << testImageFilename << ".diff.png";
+    try
+      {
+      rescale->SetInput( diff->GetOutput() );
+      rescale->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during rescale of " << diffName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during rescale of " << diffName.str() << std::endl;
+      }
+    writer->SetFileName( diffName.str().c_str() );
+    try
+      {
+      writer->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during write of " << diffName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during write of " << diffName.str() << std::endl;
+      }
+
+    std::cout << "<DartMeasurementFile name=\"DifferenceImage\" type=\"image/png\">";
+    std::cout << diffName.str();
+    std::cout << "</DartMeasurementFile>" << std::endl;
+
+    std::ostringstream baseName;
+    baseName << testImageFilename << ".base.png";
+    try
+      {
+      rescale->SetInput( baselineReader->GetOutput() );
+      rescale->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during rescale of " << baseName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during rescale of " << baseName.str() << std::endl;
+      }
+    try
+      {
+      writer->SetFileName( baseName.str().c_str() );
+      writer->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during write of " << baseName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during write of " << baseName.str() << std::endl;
+      }
+
+    std::cout << "<DartMeasurementFile name=\"BaselineImage\" type=\"image/png\">";
+    std::cout << baseName.str();
+    std::cout << "</DartMeasurementFile>" << std::endl;
+
+    std::ostringstream testName;
+    testName << testImageFilename << ".test.png";
+    try
+      {
+      rescale->SetInput( testReader->GetOutput() );
+      rescale->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during rescale of " << testName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during rescale of " << testName.str() << std::endl;
+      }
+    try
+      {
+      writer->SetFileName( testName.str().c_str() );
+      writer->Update();
+      }
+    catch ( const std::exception & e )
+      {
+      std::cerr << "Error during write of " << testName.str() << std::endl;
+      std::cerr << e.what() << "\n";
+      }
+    catch ( ... )
+      {
+      std::cerr << "Error during write of " << testName.str() << std::endl;
+      }
+
+    std::cout << "<DartMeasurementFile name=\"TestImage\" type=\"image/png\">";
+    std::cout << testName.str();
+    std::cout << "</DartMeasurementFile>" << std::endl;
+    }
+  return ( status > numberOfPixelsTolerance ) ? 1 : 0;
+}
+
+//
+// Generate all of the possible baselines
+// The possible baselines are generated fromn the baselineFilename using the
+// following algorithm:
+// 1) strip the suffix
+// 2) append a digit .x
+// 3) append the original suffix.
+// It the file exists, increment x and continue
+//
+std::map< std::string, int > RegressionTestBaselines(char *baselineFilename)
+{
+  std::map< std::string, int > baselines;
+  baselines[std::string(baselineFilename)] = 0;
+
+  std::string originalBaseline(baselineFilename);
+
+  int                    x = 0;
+  std::string::size_type suffixPos = originalBaseline.rfind(".");
+  std::string            suffix;
+  if ( suffixPos != std::string::npos )
+    {
+    suffix = originalBaseline.substr( suffixPos, originalBaseline.length() );
+    originalBaseline.erase( suffixPos, originalBaseline.length() );
+    }
+  while ( ++x )
+    {
+    std::ostringstream filename;
+    filename << originalBaseline << "." << x << suffix;
+    std::ifstream filestream( filename.str().c_str() );
+    if ( !filestream )
+      {
+      break;
+      }
+    baselines[filename.str()] = 0;
+    filestream.close();
+    }
+  return baselines;
+}
+
+#endif


### PR DESCRIPTION
This version of the patch simply copies the current ConvertBetweenFileFormats from ITKApps.

It would be possible to use an ExternalProject to download the source for ITKApps and reference the ConvertBetweenFileFormats directory for a build, but this seemed more direct.
