### PR TITLE
ENH: increase dilation of ROI to deal with faiure of ROIAuto for really

### DIFF
--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -170,13 +170,14 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
       // Register each intrasubject image mode to first image
       intraSubjectRegistrationHelper->SetFixedVolume(m_IntraSubjectOriginalImageList[0]);
       // TODO: Find way to turn on histogram equalization for same mode images
+      const int dilateSize = 15;
       intraSubjectRegistrationHelper->SetMovingVolume(m_IntraSubjectOriginalImageList[i]);
         {
         muLogMacro( << "Generating MovingImage Mask (Intrasubject  " << i << ")" <<  std::endl );
         typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
         typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
         ROIFilter->SetInput(m_IntraSubjectOriginalImageList[i]);
-        ROIFilter->SetDilateSize(3); // Only use a very small non-tissue
+        ROIFilter->SetDilateSize(dilateSize); // Only use a very small non-tissue
         // region outside of head during initial
         // runnings
         ROIFilter->Update();
@@ -206,7 +207,7 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
           typedef itk::BRAINSROIAutoImageFilter<InternalImageType, itk::Image<unsigned char, 3> > ROIAutoType;
           typename ROIAutoType::Pointer  ROIFilter = ROIAutoType::New();
           ROIFilter->SetInput(m_IntraSubjectOriginalImageList[0]);
-          ROIFilter->SetDilateSize(3); // Only use a very small non-tissue
+          ROIFilter->SetDilateSize(dilateSize); // Only use a very small non-tissue
           // region outside of head during
           // initial runnings
           ROIFilter->Update();


### PR DESCRIPTION
Hi all, 

This is what Hans and I came up with to deal with ROIAuto Failure for those T2 image with suppressed skulls. 
I tested on ONE subject and it seems working. Hans and I tested the exact same parameter for two subjects, and they worked. 

Thanks!

Regina
ENH: increase dilation of ROI to deal with faiure of ROIAuto for really dark (supressed) skulls
