### PR TITLE
COMP: kill warnings due to uninitialized variables in DWIConvert

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -777,7 +777,7 @@ int main(int argc, char *argv[])
     ImageOrigin[2] = origin[2];
     }
 
-    unsigned int numberOfSlicesPerVolume;
+    unsigned int numberOfSlicesPerVolume = 0;
     std::map<std::string,int> sliceLocations;
     if(!multiSliceVolume)
       {

--- a/DWIConvert/FSLToNrrd.cxx
+++ b/DWIConvert/FSLToNrrd.cxx
@@ -37,8 +37,8 @@ FSLToNrrd(const std::string &inputVolume,
     }
   std::vector<double> BVals;
   std::vector< std::vector<double> > BVecs;
-  unsigned int bValCount;
-  unsigned int bVecCount;
+  unsigned int bValCount = 0;
+  unsigned int bVecCount = 0;
   double maxBValue(0.0);
   if(ReadBVals(BVals,bValCount,inputBValues,maxBValue) != EXIT_SUCCESS)
     {


### PR DESCRIPTION
Don't know how this wasn't already in BRAINSia/BRAINSStandAlone
