### PR TITLE
COMP: Update to current master ITK, fix incompatibilities

### DIFF
--- a/BRAINSCommonLib/GenericTransformImage.hxx
+++ b/BRAINSCommonLib/GenericTransformImage.hxx
@@ -4,6 +4,7 @@
 #include <iostream>
 #include "GenericTransformImage.h"
 #include "itkResampleInPlaceImageFilter.h"
+#include "itkConstantBoundaryCondition.h"
 
 template <class InputImageType, class OutputImageType>
 typename OutputImageType::Pointer

--- a/BRAINSSnapShotWriter/BRAINSSnapShotWriter.cxx
+++ b/BRAINSSnapShotWriter/BRAINSSnapShotWriter.cxx
@@ -9,7 +9,7 @@
 #include "itkTileImageFilter.h"
 #include "itkFlipImageFilter.h"
 #include "itkLabelOverlayImageFilter.h"
-#include "itkComposeRGBImageFilter.h"
+#include "itkComposeImageFilter.h"
 #include "itkRGBPixel.h"
 
 #include "BRAINSSnapShotWriterCLP.h"
@@ -357,8 +357,8 @@ main(int argc, char * *argv)
                                         OutputGreyImageType,
                                         OutputRGBImageType > LabelOverlayFilter;
 
-  typedef itk::ComposeRGBImageFilter< OutputGreyImageType, 
-                                      OutputRGBImageType > RGBComposeFilter;
+  typedef itk::ComposeImageFilter< OutputGreyImageType,
+                                   OutputRGBImageType > RGBComposeFilter;
 
   typedef std::vector< OutputRGBImageType::Pointer > OutputRGBImageVectorType;
 

--- a/ImageCalculator/ImageCalculatorTemplates.h
+++ b/ImageCalculator/ImageCalculatorTemplates.h
@@ -26,7 +26,6 @@ PURPOSE.  See the above copyright notices for more information.
 #include "itkCastImageFilter.h"
 #include "itkOrientImageFilter.h"
 #include "itkSpatialOrientation.h"
-#include "itkAnalyzeImageIO.h"
 #include "itkMetaDataObject.h"
 #include "itkLabelStatisticsImageFilter.h"
 #include <itkSmartPointer.h>

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -81,7 +81,8 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
     )
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
-  set(${proj}_GIT_TAG 4745c6654b968545d0e3328520e7907d50bab22c) #2012-12-15
+#  set(${proj}_GIT_TAG 4745c6654b968545d0e3328520e7907d50bab22c) #2012-12-15
+  set(${proj}_GIT_TAG v4.3.1)
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
I tried a clean build of BRAINSStandAlone and ran into problems
building ITK. So I updated to the current release 4.3.1, and
had to fix problems that appear to be covered under the ITKv4
Migration guides.
