### PR TITLE
SLC2013 using BRAINS for prostate registration: extra features and bug fixes

### DIFF
--- a/BRAINSCommonLib/BRAINSFitBSpline.h
+++ b/BRAINSCommonLib/BRAINSFitBSpline.h
@@ -127,15 +127,22 @@ DoBSpline(typename BSplineTransformType::Pointer InitializerBsplineTransform,
   // the parameters to something different than those control points inside the
   // fixed image mask.
   OptimizerBoundSelectionType boundSelect( m_OutputBSplineTransform->GetNumberOfParameters() );
+  OptimizerBoundValueType     upperBound( m_OutputBSplineTransform->GetNumberOfParameters() );
+  OptimizerBoundValueType     lowerBound( m_OutputBSplineTransform->GetNumberOfParameters() );
+
   if( vcl_abs(m_MaxBSplineDisplacement) < 1e-12 )
     {
     boundSelect.Fill(0);
+    // even when optimization is unbounded, bounds are checked in
+    // LBFGSBOptimizer::StartOptimization()
+    upperBound.Fill(m_MaxBSplineDisplacement);
+    lowerBound.Fill(-m_MaxBSplineDisplacement);
+    optimizer->SetUpperBound(upperBound);
+    optimizer->SetLowerBound(lowerBound);
     }
   else
     {
     boundSelect.Fill(2);
-    OptimizerBoundValueType     upperBound( m_OutputBSplineTransform->GetNumberOfParameters() );
-    OptimizerBoundValueType     lowerBound( m_OutputBSplineTransform->GetNumberOfParameters() );
 
     upperBound.Fill(m_MaxBSplineDisplacement);
     lowerBound.Fill(-m_MaxBSplineDisplacement);

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -570,6 +570,16 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
 
   appMutualRegistration->SetNumberOfIterations( numberOfIterations);
 
+  // Set binary masks
+  if( m_FixedBinaryVolume.IsNotNull() )
+    {
+    appMutualRegistration->SetFixedBinaryVolume(m_FixedBinaryVolume);
+    }
+  if( m_MovingBinaryVolume.IsNotNull() )
+    {
+    appMutualRegistration->SetMovingBinaryVolume(m_MovingBinaryVolume);
+    }
+
   // TODO:  What do the following two lines really accomplish
   // debug parameter, suppressed from command line
   const bool initialTransformPassThru(false);

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -234,19 +234,20 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
     try
       {
       if( initialTransform.size() > 0 )
-	{
-	std::cout << "Read ITK transform from file: " << initialTransform << std::endl;
+	      {
+	      std::cout << "Read ITK transform from file: " << initialTransform << std::endl;
 
-	transformListReader->SetFileName( initialTransform.c_str() );
-	transformListReader->Update();
+	      transformListReader->SetFileName( initialTransform.c_str() );
+	      transformListReader->Update();
 
-	currentTransformList = *( transformListReader->GetTransformList() );
-	if( currentTransformList.size() == 0 )
-	  {
-	  itkGenericExceptionMacro( << "Number of currentTransformList = " << currentTransformList.size()
-	    << "FATAL ERROR: Failed to read transform" << initialTransform);
-	  }
-	}
+	      currentTransformList = *( transformListReader->GetTransformList() );
+	      if( currentTransformList.size() == 0 )
+	        {
+	        itkGenericExceptionMacro( << "Number of currentTransformList = " << currentTransformList.size()
+	          << "FATAL ERROR: Failed to read transform" << initialTransform);
+	        }
+        std::cout << "HACK: " << currentTransformList.size() << "  " << ( *( currentTransformList.begin() ) )->GetNameOfClass() << std::endl;
+	      }
       }
     catch( itk::ExceptionObject & excp )
       {
@@ -255,7 +256,7 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
       std::cerr << excp << std::endl;
       throw excp;
       }
-    std::cout << "HACK: " << currentTransformList.size() << "  " << ( *( currentTransformList.begin() ) )->GetNameOfClass() << std::endl;
+
   if( currentTransformList.size() == 1 )  // Most simple transform types
     {
     // NOTE:  The dynamic casting here circumvents the standard smart pointer

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -442,6 +442,15 @@ public:
 
   itkGetConstObjectMacro(MovingImage, MovingImageType);
 
+  /** Set/Get binary masks. */
+  void SetFixedBinaryVolume(FixedBinaryVolumePointer fixedBinaryMask);
+
+  itkGetConstObjectMacro(FixedBinaryVolume, FixedBinaryVolumeType);
+
+  void SetMovingBinaryVolume(MovingBinaryVolumePointer movingBinaryMask);
+
+  itkGetConstObjectMacro(MovingBinaryVolume, MovingBinaryVolumeType);
+
   /** Set/Get the InitialTransfrom. */
   void SetInitialTransform(typename TransformType::Pointer initialTransform);
   itkGetConstObjectMacro(InitialTransform, TransformType);
@@ -529,6 +538,8 @@ private:
 
   FixedImagePointer  m_FixedImage;
   MovingImagePointer m_MovingImage;
+  FixedBinaryVolumePointer m_FixedBinaryVolume;
+  MovingBinaryVolumePointer m_MovingBinaryVolume;
   TransformPointer   m_InitialTransform;
   TransformPointer   m_Transform;
   //

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -551,6 +551,29 @@ template <typename TTransformType, typename TOptimizer, typename TFixedImage,
 void
 MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                      TMovingImage, MetricType>
+::SetFixedBinaryVolume(FixedBinaryVolumePointer fixedMask)
+{
+  itkDebugMacro("setting Fixed Image mask to " << fixedMask);
+  this->m_FixedBinaryVolume = fixedMask;
+}
+
+template <typename TTransformType, typename TOptimizer, typename TFixedImage,
+          typename TMovingImage, typename MetricType>
+void
+MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
+                                     TMovingImage, MetricType>
+::SetMovingBinaryVolume(MovingBinaryVolumePointer movingMask)
+{
+  itkDebugMacro("setting Moving Image to " << movingMask);
+  this->m_MovingBinaryVolume = movingMask;
+}
+
+
+template <typename TTransformType, typename TOptimizer, typename TFixedImage,
+          typename TMovingImage, typename MetricType>
+void
+MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
+                                     TMovingImage, MetricType>
 ::SetInitialTransform(typename TransformType::Pointer initialTransform)
 {
   itkDebugMacro("setting Initial Transform to " << initialTransform);

--- a/ConvertBetweenFileFormats/TestSuite/CMakeLists.txt
+++ b/ConvertBetweenFileFormats/TestSuite/CMakeLists.txt
@@ -93,7 +93,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME compare_nifti COMMAND
           $<TARGET_FILE:ImageCompareTests> --compare DATA{${TestData_DIR}/image_in.mhd,image_in.raw} ${IMAGE_PATH_OUTPUTS}/image_in8.mhd Dummy)
 set_tests_properties(compare_nifti PROPERTIES DEPENDS ccvnt_from_nifti)
 
-add_executable(ImageCompareTests ImageCompareTests.cxx)
+add_executable(ImageCompareTests ../ImageCompareTests.cxx)
 target_link_libraries(ImageCompareTests ${ITK_LIBRARIES})
 
 ExternalData_Add_Target( ${PROJECT_NAME}FetchData )  # Name of data management target


### PR DESCRIPTION
This patch is for the tag of BRAINS used in Slicer superbuild.
