### PR TITLE
BUG: revert setting binary masks for registration method

### DIFF
--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -564,16 +564,6 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
 
   appMutualRegistration->SetNumberOfIterations( numberOfIterations);
 
-  // Set binary masks
-  if( m_FixedBinaryVolume.IsNotNull() )
-    {
-    appMutualRegistration->SetFixedBinaryVolume(m_FixedBinaryVolume);
-    }
-  if( m_MovingBinaryVolume.IsNotNull() )
-    {
-    appMutualRegistration->SetMovingBinaryVolume(m_MovingBinaryVolume);
-    }
-
   // TODO:  What do the following two lines really accomplish
   // debug parameter, suppressed from command line
   const bool initialTransformPassThru(false);
@@ -587,6 +577,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::FitCommonCode(
   appMutualRegistration->SetReproportionScale( m_ReproportionScale );
   appMutualRegistration->SetSkewScale( m_SkewScale );
 
+  // NOTE: binary masks are set for the cost metric object!!!
   appMutualRegistration->SetFixedImage(    m_FixedVolume    );
   appMutualRegistration->SetMovingImage(   m_MovingVolume   );
   appMutualRegistration->SetCostMetricObject( this->m_CostMetricObject );

--- a/BRAINSCommonLib/genericRegistrationHelper.h
+++ b/BRAINSCommonLib/genericRegistrationHelper.h
@@ -442,15 +442,6 @@ public:
 
   itkGetConstObjectMacro(MovingImage, MovingImageType);
 
-  /** Set/Get binary masks. */
-  void SetFixedBinaryVolume(FixedBinaryVolumePointer fixedBinaryMask);
-
-  itkGetConstObjectMacro(FixedBinaryVolume, FixedBinaryVolumeType);
-
-  void SetMovingBinaryVolume(MovingBinaryVolumePointer movingBinaryMask);
-
-  itkGetConstObjectMacro(MovingBinaryVolume, MovingBinaryVolumeType);
-
   /** Set/Get the InitialTransfrom. */
   void SetInitialTransform(typename TransformType::Pointer initialTransform);
   itkGetConstObjectMacro(InitialTransform, TransformType);
@@ -538,8 +529,6 @@ private:
 
   FixedImagePointer  m_FixedImage;
   MovingImagePointer m_MovingImage;
-  FixedBinaryVolumePointer m_FixedBinaryVolume;
-  MovingBinaryVolumePointer m_MovingBinaryVolume;
   TransformPointer   m_InitialTransform;
   TransformPointer   m_Transform;
   //

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -551,29 +551,6 @@ template <typename TTransformType, typename TOptimizer, typename TFixedImage,
 void
 MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
                                      TMovingImage, MetricType>
-::SetFixedBinaryVolume(FixedBinaryVolumePointer fixedMask)
-{
-  itkDebugMacro("setting Fixed Image mask to " << fixedMask);
-  this->m_FixedBinaryVolume = fixedMask;
-}
-
-template <typename TTransformType, typename TOptimizer, typename TFixedImage,
-          typename TMovingImage, typename MetricType>
-void
-MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
-                                     TMovingImage, MetricType>
-::SetMovingBinaryVolume(MovingBinaryVolumePointer movingMask)
-{
-  itkDebugMacro("setting Moving Image to " << movingMask);
-  this->m_MovingBinaryVolume = movingMask;
-}
-
-
-template <typename TTransformType, typename TOptimizer, typename TFixedImage,
-          typename TMovingImage, typename MetricType>
-void
-MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
-                                     TMovingImage, MetricType>
 ::SetInitialTransform(typename TransformType::Pointer initialTransform)
 {
   itkDebugMacro("setting Initial Transform to " << initialTransform);


### PR DESCRIPTION
The masks are set on the cost metric object!
