### PR TITLE
COMP: add patch to work around CLang 3.3 confusion about alloca

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -166,17 +166,15 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
     BUILD_COMMAND ${VTK_BUILD_STEP}
     )
 
-  if(APPLE)
-    set(VTKlongbranchPatchScript ${CMAKE_CURRENT_LIST_DIR}/VTKPatch.cmake)
-    ExternalProject_Add_Step(${proj} RmLongBranch
-      COMMENT "get rid of obsolete C/CXX flags"
-      DEPENDEES download
-      DEPENDERS configure
-      COMMAND ${CMAKE_COMMAND}
-      -DVTKSource=<SOURCE_DIR>
-      -P ${VTKlongbranchPatchScript}
+  set(VTKPatchScript ${CMAKE_CURRENT_LIST_DIR}/VTKPatch.cmake)
+  ExternalProject_Add_Step(${proj} VTKPatch
+    COMMENT "get rid of obsolete C/CXX flags"
+    DEPENDEES download
+    DEPENDERS configure
+    COMMAND ${CMAKE_COMMAND}
+    -DVTKSource=<SOURCE_DIR>
+    -P ${VTKPatchScript}
     )
-  endif(APPLE)
 
   set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 else()

--- a/SuperBuild/VTKPatch.cmake
+++ b/SuperBuild/VTKPatch.cmake
@@ -23,3 +23,29 @@ file(READ ${ftglCMakeLists_txt}
 string(REPLACE " -fpascal-strings" "" code "${code}")
 
 file(WRITE ${ftglCMakeLists_txt} "${code}")
+
+#set(vtkVRMLImporter
+#  ${VTKSource}/IO/Import/vtkVRMLImporter.cxx)
+file(GLOB_RECURSE vtkVRMLImporter RELATIVE ${VTKSource} "vtkVRMLImporter.cxx")
+set(vtkVRMLImporter "${VTKSource}/${vtkVRMLImporter}")
+message("vtkVRMLImporter=${vtkVRMLImporter}")
+
+file(READ ${vtkVRMLImporter}
+  code)
+
+string(REPLACE
+"#ifdef __GNUC__
+#undef alloca
+#define alloca __builtin_alloca
+"
+"#ifdef __GNUC__
+#ifndef __clang__
+#undef alloca
+#define alloca __builtin_alloca
+#endif
+"
+code "${code}")
+
+file(WRITE ${vtkVRMLImporter}
+  "${code}"
+  )


### PR DESCRIPTION
This is a case where CLang's imperfect impersonation of GCC causes a compile error.  This adds to the patch script we use when building VTK.
