### PR TITLE
COMP: Trust SVN Cert for NITRC

### DIFF
--- a/DWIConvert/DWIConvert.cxx
+++ b/DWIConvert/DWIConvert.cxx
@@ -1912,7 +1912,6 @@ int main(int argc, char *argv[])
       {
       //
       // copy the computed reference frame to the image so that NIFTI
-
       // writes the correct stuff out. NIFTI writer
       // expects RAS?
       itk::Matrix<double,3,3> NIfTIDirCos = LPSDirCos;
@@ -2054,7 +2053,7 @@ int main(int argc, char *argv[])
       // in nrrd, size array is the number of pixels in 1st, 2nd, 3rd, ... dimensions
       header << "sizes: " << nCols << " " << nRows << " " << nSliceInVolume << " " << nUsableVolumes << std::endl;
       header << "thicknesses:  NaN  NaN " << sliceSpacing << " NaN" << std::endl;
-
+      header.setprecision(17);
       // need to check
       header << "space directions: "
              << "(" << (NRRDSpaceDirection[0][0]) << ","<< (NRRDSpaceDirection[1][0]) << ","<< (NRRDSpaceDirection[2][0]) << ") "

--- a/SuperBuild/External_ReferenceAtlas.cmake
+++ b/SuperBuild/External_ReferenceAtlas.cmake
@@ -72,6 +72,7 @@ if(NOT DEFINED ${extProjName}_DIR OR NOT DEFINED ATLAS_NAME)
     SVN_REVISION -r ${ATLAS_SVN_REVISION}
     SVN_USERNAME slicerbot
     SVN_PASSWORD slicer
+    SVN_TRUST_CERT
     SOURCE_DIR ${proj}
     BINARY_DIR ${proj}-build
     "${cmakeversion_external_update}"


### PR DESCRIPTION
If you don't add SVN_TRUST_CERT to ExternalProjects with SVN repositories, every person using BRAINSStandAlone will have to do a manual checkout of the reference atlas in order to permanently accept the nitrc.org SSL certificate.
