### PR TITLE
ENH: GLOBAL_DATA_SINK_REWRITE

### DIFF
--- a/AutoWorkup/WorkupT1T2.py
+++ b/AutoWorkup/WorkupT1T2.py
@@ -39,10 +39,10 @@ from PipeLineFunctionHelpers import POSTERIORS
 from PipeLineFunctionHelpers import UnwrapPosteriorImagesFromDictionaryFunction
 from PipeLineFunctionHelpers import FixWMPartitioning
 from PipeLineFunctionHelpers import AccumulateLikeTissuePosteriors
-from WorkupT1T2FreeSurfer_custom import CreateFreeSurferWorkflow_custom, CreateFreeSurferSubjectTemplate, CreateFreeSurferLongitudinalWorkflow
+from WorkupT1T2FreeSurfer_custom import (CreateFreeSurferWorkflow_custom,
+                                         CreateFreeSurferSubjectTemplate,
+                                         CreateFreeSurferLongitudinalWorkflow)
 
-#GLOBAL_DATA_SINK_REWRITE = True
-GLOBAL_DATA_SINK_REWRITE = False
 
 # HACK:  [('buildTemplateIteration2', 'SUBJECT_TEMPLATES/0249/buildTemplateIteration2')]
 


### PR DESCRIPTION
ENH: global value is configurable from the command line and the configuration file.

Usage:
    baw_exp.py --ignore_datasinks ...
       Sets GLOBAL_DATA_SINK_REWRITE == False

```
In configuration file:
   [PIPELINE]
   IGNORE_DATASINKS = True

   Sets GLOBAL_DATA_SINK_REWRITE == False
```
