### PR TITLE
COMP: Review use of iostream & use double-conversion where needed

### DIFF
--- a/BRAINSABC/brainseg/AtlasDefinition.cxx
+++ b/BRAINSABC/brainseg/AtlasDefinition.cxx
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <itksys/SystemTools.hxx>
+#include "DoubleToString.h"
 
 namespace // anon
 {
@@ -119,12 +120,39 @@ AtlasDefinition::XMLStart(const char *el)
     }
 }
 
+double
+AtlasDefinition
+::StrToD(const char *str,const char *message) const
+{
+  char *last;
+  double rval = strtod(str,&last);
+  if(str == static_cast<const char *>(last))
+    {
+    std::cerr << message << ' ' << this->m_LastXMLString << std::endl;
+    throw;
+    }
+  return rval;
+}
+
+long
+AtlasDefinition
+::StrToL(const char *str,const char *message) const
+{
+  char *last;
+  long rval = strtol(str,&last,10);
+  if(str == static_cast<const char *>(last))
+    {
+    std::cerr << message << ' ' << this->m_LastXMLString << std::endl;
+    throw;
+    }
+  return rval;
+}
+
 void
 AtlasDefinition::XMLEnd(const char *el)
 {
   std::string El(el);
   const char *start = this->m_LastXMLString.c_str();
-  char *      last;
 
   // pop the current element name off the stack.
   this->m_XMLElementStack.pop_back();
@@ -155,80 +183,31 @@ AtlasDefinition::XMLEnd(const char *el)
     }
   else if( El == "Weight" )
     {
-    double w = strtod(start, &last);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad Weight given " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastWeight = w;
+    this->m_LastWeight = this->StrToD(start,"Bad Weight given");
     }
   else if( El == "lower" )
     {
-    double l = strtod(start, &last);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad lower bound " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastLower = l;
+    this->m_LastLower = this->StrToD(start,"Bad lower bound");
     }
   else if( El == "upper" )
     {
-    double u = strtod(start, &last);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad upper bound " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastUpper = u;
+    this->m_LastUpper = this->StrToD(start,"Bad upper bound");
     }
   else if( El == "GaussianClusterCount" )
     {
-    int GCC = strtol(start, &last, 10);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad GaussianClusterCount given " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastGaussianClusterCount = GCC;
+    this->m_LastGaussianClusterCount = this->StrToL(start,"Bad GaussianClusterCount");
     }
   else if( El == "LabelCode" )
     {
-    int GCC = strtol(start, &last, 10);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad LabelCode given " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastLabelCode = GCC;
+    this->m_LastLabelCode = this->StrToL(start,"Bad LabelCode");
     }
   else if( El == "UseForBias" )
     {
-    int UFB = strtol(start, &last, 10);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad UseForBias given " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastUseForBias = UFB;
+    this->m_LastUseForBias = this->StrToL(start,"Bad UseForBias");
     }
   else if( El == "IsForegroundPrior" )
     {
-    int UFB = strtol(start, &last, 10);
-    if( start == (const char *)last )
-      {
-      std::cerr << "Bad IsForegroundPrior given " << this->m_LastXMLString
-                << std::endl;
-      throw;
-      }
-    this->m_LastIsForegroundPrior = UFB;
+    this->m_LastIsForegroundPrior = this->StrToL(start,"Bad IsForegroundPrior");
     }
   else if( El == "BrainMask" )
     {
@@ -301,7 +280,16 @@ AtlasDefinition::InitFromXML(const std::string & XMLFilename)
     }
   xmlFile.close();
 
-  if( XML_Parse(parser, filebuf, fSize, 1) == 0 )
+  int parserReturn(1);
+  try
+    {
+    parserReturn = XML_Parse(parser, filebuf, fSize, 1);
+    }
+  catch(...)
+    {
+    parserReturn = 0;
+    }
+  if(!parserReturn)
     {
     delete[] filebuf;
     std::cerr << "XML File parsing error" << std::endl;
@@ -313,6 +301,7 @@ AtlasDefinition::InitFromXML(const std::string & XMLFilename)
 void
 AtlasDefinition::DebugPrint()
 {
+  DoubleToString doubleConvert;
   std::cout << "<Atlas>" << std::endl;
   for( TemplateMap::iterator it
          = m_TemplateVolumes.begin();
@@ -349,7 +338,7 @@ AtlasDefinition::DebugPrint()
               << it->second.GetFilename()
               << "</filename>" << std::endl
               << "    <Weight>"
-              << it->second.GetWeight()
+              << doubleConvert(it->second.GetWeight())
               << "</Weight>" << std::endl
               << "    <GaussianClusterCount>"
               << it->second.GetGaussianClusterCount()
@@ -374,10 +363,10 @@ AtlasDefinition::DebugPrint()
                 << it2->first
                 << "</type>" << std::endl
                 << "      <lower>"
-                << it2->second.GetLower()
+                << doubleConvert(it2->second.GetLower())
                 << "</lower>" << std::endl
                 << "      <upper>"
-                << it2->second.GetUpper()
+                << doubleConvert(it2->second.GetUpper())
                 << "<upper>" << std::endl
                 << "    </bounds>" << std::endl;
       }

--- a/BRAINSABC/brainseg/AtlasDefinition.h
+++ b/BRAINSABC/brainseg/AtlasDefinition.h
@@ -6,7 +6,7 @@
 #include <list>
 #include <map>
 #include <iostream>
-
+#include "DoubleToString.h"
 /** \class AtlasDefiniton */
 class AtlasDefinition
 {
@@ -18,41 +18,42 @@ public:
   typedef std::vector<int>                   IntVector;
   /** \class BoundsType */
   class BoundsType
-    {
+  {
   public:
     BoundsType() : m_Low(0), m_High(0)
-    {
-    }
+      {
+      }
 
     void SetLower(const double v)
       {
-      m_Low = v;
+        m_Low = v;
       }
 
     double GetLower() const
       {
-      return m_Low;
+        return m_Low;
       }
 
     void SetUpper(const double v)
       {
-      m_High = v;
+        m_High = v;
       }
 
     double GetUpper() const
       {
-      return m_High;
+        return m_High;
       }
 
     void Print(void) const
       {
-      std::cout << "RANGE:  [" << m_Low << "," << m_High << "]" << std::endl;
+        DoubleToString ds;
+        std::cout << "RANGE:  [" << ds(m_Low) << "," << ds(m_High) << "]" << std::endl;
       }
 
   private:
     double m_Low;
     double m_High;
-    };
+  };
   typedef std::map<std::string, BoundsType> BoundsMapType;
 
   AtlasDefinition();
@@ -62,150 +63,150 @@ public:
 
   const TemplateMap & GetTemplateVolumes() const
     {
-    return m_TemplateVolumes;
+      return m_TemplateVolumes;
     }
 
   const std::string & GetTemplateBrainMask() const
     {
-    return m_TemplateBrainMask;
+      return m_TemplateBrainMask;
     }
 
   const std::string & GetTemplateHeadRegion() const
     {
-    return m_TemplateHeadRegion;
+      return m_TemplateHeadRegion;
     }
 
   std::string GetPriorFilename(const std::string & tissueType) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetFilename();
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetFilename();
     }
 
   double GetWeight(const std::string & tissueType) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetWeight();
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetWeight();
     }
 
   int GetGaussianClusterCount(const std::string & tissueType) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetGaussianClusterCount();
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetGaussianClusterCount();
     }
 
   int GetLabelCode(const std::string & tissueType) const
     {
-    //HACK:  All the get functions need review to remove duplicate code.
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING LABEL CODE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetLabelCode();
+      //HACK:  All the get functions need review to remove duplicate code.
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING LABEL CODE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetLabelCode();
     }
 
   int GetUseForBias(const std::string & tissueType) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetUseForBias();
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetUseForBias();
     }
 
   bool GetIsForegroundPrior(const std::string & tissueType) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING IsForegroungPrior IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetIsForegroundPrior();
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING IsForegroungPrior IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetIsForegroundPrior();
     }
 
   const BoundsType & GetBounds(const std::string & tissueType,
-    const std::string & Modality) const
+                               const std::string & Modality) const
     {
-    if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
-      {
-      std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
-      throw;
-      }
-    PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
-    if( mit == m_PriorMap.end() )
-      {
-      // HACK:  Should throw and exception here with line number and file
-      std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
-      throw;
-      }
-    return mit->second.GetBounds(Modality);
+      if( m_PriorMap.find(tissueType) == m_PriorMap.end() )
+        {
+        std::cout << "MISSING TISSUE TYPE IN ATLAS:  " << tissueType << std::endl;
+        throw;
+        }
+      PriorMapType::const_iterator mit = m_PriorMap.find(tissueType);
+      if( mit == m_PriorMap.end() )
+        {
+        // HACK:  Should throw and exception here with line number and file
+        std::cout << "ERROR:  Invalid tissueType requested in GetPriorFilename" << std::endl;
+        throw;
+        }
+      return mit->second.GetBounds(Modality);
     }
 
   double GetLow(const std::string & tissueType,
-    const std::string & Modality) const
+                const std::string & Modality) const
     {
-    return this->GetBounds(tissueType, Modality).GetLower();
+      return this->GetBounds(tissueType, Modality).GetLower();
     }
 
   double GetHigh(const std::string & tissueType,
-    const std::string & Modality) const
+                 const std::string & Modality) const
     {
-    return this->GetBounds(tissueType, Modality).GetUpper();
+      return this->GetBounds(tissueType, Modality).GetUpper();
     }
 
   const TissueTypeVector & TissueTypes();
@@ -217,12 +218,17 @@ public:
   void XMLChar(const char *buf);
 
 private:
+  /** convert to float or throw exception on failure */
+  double StrToD(const char *str,const char *message) const;
+  /** convert to long or throw exception on failure */
+  long   StrToL(const char *str,const char *message) const;
+
   TemplateMap      m_TemplateVolumes;
   std::string      m_TemplateBrainMask;
   std::string      m_TemplateHeadRegion;
   TissueTypeVector m_TissueTypes;
   class Prior
-    {
+  {
   public:
     Prior() : 
       m_Weight(0.0),
@@ -230,103 +236,103 @@ private:
       m_LabelCode(0),
       m_UseForBias(false),
       m_IsForegroundPrior(false)
-    {
-    }
+      {
+      }
 
     const std::string & GetFilename() const
       {
-      return m_Filename;
+        return m_Filename;
       }
 
     void SetFilename(const std::string & s)
       {
-      m_Filename = s;
+        m_Filename = s;
       }
 
     double GetWeight() const
       {
-      return m_Weight;
+        return m_Weight;
       }
 
     void SetWeight(double x)
       {
-      m_Weight = x;
+        m_Weight = x;
       }
 
     int GetGaussianClusterCount() const
       {
-      return m_GaussianClusterCount;
+        return m_GaussianClusterCount;
       }
 
     void SetGaussianClusterCount(int i)
       {
-      m_GaussianClusterCount = i;
+        m_GaussianClusterCount = i;
       }
 
     int GetLabelCode() const
       {
-      return m_LabelCode;
+        return m_LabelCode;
       }
 
     void SetLabelCode(const int i)
       {
-      m_LabelCode = i;
+        m_LabelCode = i;
       }
 
     int GetUseForBias() const
       {
-      return m_UseForBias;
+        return m_UseForBias;
       }
 
     void SetUseForBias(const bool i)
       {
-      m_UseForBias = i;
+        m_UseForBias = i;
       }
 
     int GetIsForegroundPrior() const
       {
-      return m_IsForegroundPrior;
+        return m_IsForegroundPrior;
       }
 
     void SetIsForegroundPrior(const bool i)
       {
-      m_IsForegroundPrior = i;
+        m_IsForegroundPrior = i;
       }
 
     const BoundsType & GetBounds(const std::string & Modality) const
       {
-      BoundsMapType::const_iterator bit= m_BoundsMap.find(Modality);
-      if(bit == m_BoundsMap.end() )
-        {
-        std::cout << "MISSING MODALIITY TYPE IN ATLAS:  " << Modality << std::endl;
-        throw;
-        }
+        BoundsMapType::const_iterator bit= m_BoundsMap.find(Modality);
+        if(bit == m_BoundsMap.end() )
+          {
+          std::cout << "MISSING MODALIITY TYPE IN ATLAS:  " << Modality << std::endl;
+          throw;
+          }
 
-      return bit->second;
+        return bit->second;
       }
 
     void SetBounds(const std::string & Modality, const BoundsType & b)
       {
-      this->m_BoundsMap[Modality] = b;
+        this->m_BoundsMap[Modality] = b;
       }
 
     void SetBounds(const std::string & Modality, double lower, double upper)
       {
-      BoundsType b;
+        BoundsType b;
 
-      b.SetLower(lower);
-      b.SetUpper(upper);
-      this->SetBounds(Modality, b);
+        b.SetLower(lower);
+        b.SetUpper(upper);
+        this->SetBounds(Modality, b);
       }
 
     void SetBoundsList(BoundsMapType & boundsMap)
       {
-      this->m_BoundsMap = boundsMap;
+        this->m_BoundsMap = boundsMap;
       }
 
     const BoundsMapType & GetBoundsList() const
       {
-      return this->m_BoundsMap;
+        return this->m_BoundsMap;
       }
 
   private:
@@ -337,7 +343,7 @@ private:
     bool          m_UseForBias;
     bool          m_IsForegroundPrior;
     BoundsMapType m_BoundsMap;
-    };
+  };
   typedef std::map<std::string, Prior> PriorMapType;
   PriorMapType m_PriorMap;
   //
@@ -347,9 +353,10 @@ private:
   std::string            m_LastFilename;
   std::string            m_LastType;
   std::list<std::string> m_XMLElementStack;
-  double                 m_LastWeight,
-                         m_LastLower,
-                         m_LastUpper;
+
+  double m_LastWeight;
+  double m_LastLower;
+  double m_LastUpper;
 
   int           m_LastGaussianClusterCount;
   int           m_LastLabelCode;

--- a/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
+++ b/BRAINSABC/brainseg/AtlasRegistrationMethod.hxx
@@ -134,15 +134,14 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
       {
       try
         {
-        muLogMacro(
-          << "Reading transform from file: " << this->m_IntraSubjectTransformFileNames[i] << "." << std::endl);
+        muLogMacro(<< "Reading transform from file: "
+                   << this->m_IntraSubjectTransformFileNames[i] << "." << std::endl);
         m_IntraSubjectTransforms[i] = itk::ReadTransformFromDisk(this->m_IntraSubjectTransformFileNames[i]);
         }
       catch( ... )
         {
-        muLogMacro(
-          << "Failed to read transform file caused exception." << this->m_IntraSubjectTransformFileNames[i]
-          <<  std::endl );
+        muLogMacro(<< "Failed to read transform file caused exception." << this->m_IntraSubjectTransformFileNames[i]
+                   <<  std::endl );
         itkExceptionMacro(<< "Failed to read transform file " <<  this->m_IntraSubjectTransformFileNames[i]);
         }
       }
@@ -349,8 +348,8 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
     muLogMacro( << "ERROR:  atlas and template image list sizes do not match. " <<   std::endl );
     muLogMacro( << "m_AtlasOriginalImageList.size() = " << m_AtlasOriginalImageList.size() <<   std::endl );
     muLogMacro( << "m_IntraSubjectTransforms.size() = " << m_IntraSubjectTransforms.size() <<   std::endl );
-    muLogMacro(
-      << "m_IntraSubjectOriginalImageList.size() = " << m_IntraSubjectOriginalImageList.size() <<   std::endl );
+    muLogMacro(<< "m_IntraSubjectOriginalImageList.size() = "
+               << m_IntraSubjectOriginalImageList.size() <<   std::endl );
     itkExceptionMacro(<< "ERROR:  atlas and template image list sizes do not match. "
                       << "m_AtlasOriginalImageList.size() = " << m_AtlasOriginalImageList.size() <<   std::endl
                       << "m_IntraSubjectTransforms.size() = " << m_IntraSubjectTransforms.size() <<   std::endl
@@ -367,15 +366,15 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
     {
     try
       {
-      muLogMacro(
-        << "Reading cached Atlas to subject transform: " << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
+      muLogMacro(<< "Reading cached Atlas to subject transform: "
+                 << this->m_AtlasToSubjectTransformFileName << "." << std::endl);
       m_AtlasToSubjectTransform = itk::ReadTransformFromDisk(this->m_AtlasToSubjectTransformFileName);
       // Note:  No need to write this transform to disk
       }
     catch( ... )
       {
-      muLogMacro(
-        << "Failed to read transform file caused exception." << this->m_AtlasToSubjectTransformFileName <<  std::endl );
+      muLogMacro(<< "Failed to read transform file caused exception."
+                 << this->m_AtlasToSubjectTransformFileName <<  std::endl );
       itkExceptionMacro(<< "Failed to read transform file " <<  this->m_AtlasToSubjectTransformFileName);
       }
     return;
@@ -460,7 +459,8 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
             writer->UseCompressionOn();
 
             std::ostringstream oss;
-            oss << this->m_OutputDebugDir << "Atlas_MovingMask_" << atlasReferenceImageIndex <<  ".nii.gz" << std::ends;
+            oss << this->m_OutputDebugDir << "Atlas_MovingMask_"
+                << atlasReferenceImageIndex <<  ".nii.gz" << std::ends;
             std::string fn = oss.str();
 
             writer->SetInput( movingMaskImage );
@@ -487,8 +487,8 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
             writer->UseCompressionOn();
 
             std::ostringstream oss;
-            oss << this->m_OutputDebugDir << "SubjectForAtlas_FixedMask_" << atlasReferenceImageIndex <<  ".nii.gz"
-                << std::ends;
+            oss << this->m_OutputDebugDir << "SubjectForAtlas_FixedMask_"
+                << atlasReferenceImageIndex <<  ".nii.gz";
             std::string fn = oss.str();
 
             writer->SetInput( fixedMaskImage );
@@ -524,9 +524,8 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
               }
             else if( atlasToSubjectInitialTransformName != "AffineTransform" )
               {
-              itkExceptionMacro(
-                <<
-                "ERROR: Invalid atlasToSubjectInitialTransformName type for m_AtlasLinearTransformChoice of type Affine" );
+              itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
+                                 << " type for m_AtlasLinearTransformChoice of type Affine" );
               }
             minimumStepSize.push_back(0.0025);
             transformType.push_back("Affine");
@@ -561,9 +560,8 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
               }
             else if( atlasToSubjectInitialTransformName != "SyN" )
               {
-              itkExceptionMacro(
-                <<
-                "ERROR: Invalid atlasToSubjectInitialTransformName type for m_AtlasLinearTransformChoice of type SyN" );
+              itkExceptionMacro( << "ERROR: Invalid atlasToSubjectInitialTransformName"
+                                 << " type for m_AtlasLinearTransformChoice of type SyN" );
               }
             minimumStepSize.push_back(0.0025);
             transformType.push_back("SyN");
@@ -572,9 +570,9 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
             }
           else
             {
-            itkExceptionMacro(
-              << "ERROR: Invalid atlasToSubjectInitialTransformName type for m_AtlasLinearTransformChoice of type "
-              << m_AtlasLinearTransformChoice);
+            itkExceptionMacro(<< "ERROR: Invalid atlasToSubjectInitialTransformName"
+                              << " type for m_AtlasLinearTransformChoice of type "
+                              << m_AtlasLinearTransformChoice);
             }
           }
 
@@ -582,10 +580,10 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
           {
           muLogMacro( << "PRE_ASSIGNMENT" <<  atlasReferenceImageIndex << "  " );
           // << transformType[0] << " first of " << transformType.size() << std::endl );
-          muLogMacro(
-            << __FILE__ << " " << __LINE__ << " " << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
-          muLogMacro(
-            << __FILE__ << " " << __LINE__ << " " << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
+          muLogMacro(<< __FILE__ << " " << __LINE__ << " "
+                     << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
+          muLogMacro(<< __FILE__ << " " << __LINE__ << " "
+                     << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
           }
         if( this->m_DebugLevel > 9 )
           {
@@ -604,10 +602,10 @@ AtlasRegistrationMethod<TOutputPixel, TProbabilityPixel>
           {
           muLogMacro( << "POST_ASSIGNMENT" <<  atlasReferenceImageIndex << "  " );
           // << transformType[0] << " first of " << transformType.size() << std::endl );
-          muLogMacro(
-            << __FILE__ << " " << __LINE__ << " " << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
-          muLogMacro(
-            << __FILE__ << " " << __LINE__ << " " << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
+          muLogMacro(<< __FILE__ << " " << __LINE__
+                     << " " << m_AtlasToSubjectTransform->GetFixedParameters() <<   std::endl );
+          muLogMacro(<< __FILE__ << " " << __LINE__
+                     << " " << m_AtlasToSubjectTransform->GetParameters() <<   std::endl );
           }
         }
       } // End generating the best initial transform for atlas T1 to subject T1

--- a/BRAINSABC/brainseg/BRAINSABC.cxx
+++ b/BRAINSABC/brainseg/BRAINSABC.cxx
@@ -551,12 +551,10 @@ int main(int argc, char * *argv)
   muLogMacro(<< "Program compiled on: " << __DATE__ << std::endl );
   muLogMacro(<< std::endl );
 
-  muLogMacro(
-    << "Hans J. Johnson - hans-johnson@uiowa.edu, has made significant"
-    << " edits to this front end of the BRAINSABC system.\n");
-  muLogMacro(
-    << "Original application was written by Marcel Prastawa - "
-    << "prastawa@sci.utah.edu, and is maintained as a separate program.\n");
+  muLogMacro(<< "Hans J. Johnson - hans-johnson@uiowa.edu, has made significant"
+             << " edits to this front end of the BRAINSABC system.\n");
+  muLogMacro(<< "Original application was written by Marcel Prastawa - "
+             << "prastawa@sci.utah.edu, and is maintained as a separate program.\n");
   muLogMacro(<< "This software is provided for research purposes only\n");
   muLogMacro(<< std::endl );
 
@@ -572,10 +570,9 @@ int main(int argc, char * *argv)
   muLogMacro(<< "Output Directory: " << outputDir << std::endl );
   muLogMacro(<< "Output Format: " << outputFormat << std::endl );
   muLogMacro(<< "Input images: \n");
-  muLogMacro(
-    << "Non-linear filtering, method: " << filterMethod << ", "
-    << filterIteration
-    << " iterations, dt = " << filterTimeStep << std::endl );
+  muLogMacro(<< "Non-linear filtering, method: " << filterMethod << ", "
+             << filterIteration
+             << " iterations, dt = " << filterTimeStep << std::endl );
 
   const AtlasDefinition::TissueTypeVector & PriorNames
     = atlasDefinitionParser.TissueTypes();
@@ -678,11 +675,9 @@ int main(int argc, char * *argv)
   AtlasDefTable.Print(oss);
   muLogMacro( << oss.str() );
   }
-  muLogMacro(
-    << "Max bias polynomial degree: " << maxBiasDegree << std::endl );
+  muLogMacro(<< "Max bias polynomial degree: " << maxBiasDegree << std::endl );
   muLogMacro(<< "Atlas warping: " << !atlasWarpingOff << std::endl );
-  muLogMacro(
-    << "Atlas warp spline grid size: " << gridSize[0] << " X "
+  muLogMacro(<< "Atlas warp spline grid size: " << gridSize[0] << " X "
     << gridSize[1] << " X "
     << gridSize[2] << std::endl );
   muLogMacro(<< std::endl );
@@ -733,12 +728,14 @@ int main(int argc, char * *argv)
     if(ti != tm.end() )
       {
       std::string                                  temp = ti->second;
-      std::cerr << "STATUS:  Atlas image of type: " << inputVolumeTypes[q] << " added with filename: " << temp << std::endl;
+      std::cerr << "STATUS:  Atlas image of type: " << inputVolumeTypes[q]
+                << " added with filename: " << temp << std::endl;
       templateVolumes[q] = temp;
       }
     else
       {
-      std::cerr << "ERROR:  Atlas image of type: " << inputVolumeTypes[q] << " not found in xml file." << std::endl;
+      std::cerr << "ERROR:  Atlas image of type: " << inputVolumeTypes[q]
+                << " not found in xml file." << std::endl;
       throw;
       }
     }
@@ -783,8 +780,7 @@ int main(int argc, char * *argv)
   std::vector<std::string> intraSubjectTransformFileNames( inputVolumes.size() );
   for( unsigned int i = 0; i < inputVolumes.size(); i++ )
     {
-    muLogMacro(
-      << "Reading image " << i + 1 << ": " << inputVolumes[i] << "...\n");
+    muLogMacro(<< "Reading image " << i + 1 << ": " << inputVolumes[i] << "...\n");
 
     ReaderPointer imgreader = ReaderType::New();
     imgreader->SetFileName( inputVolumes[i].c_str() );
@@ -910,14 +906,14 @@ int main(int argc, char * *argv)
     //             of atlas images.
     if( ( atlasIndex > 0 ) && ( templateVolumes[atlasIndex] == templateVolumes[atlasIndex - 1] ) )
       { // If they are the same name, then just use same reference
-      muLogMacro(
-        << "Referencing previous image " << atlasIndex + 1 << ": " << templateVolumes[atlasIndex] << "...\n");
+      muLogMacro(<< "Referencing previous image " << atlasIndex + 1
+                 << ": " << templateVolumes[atlasIndex] << "...\n");
       atlasOriginalImageList[atlasIndex] = atlasOriginalImageList[atlasIndex - 1];
       }
     else
       {
-      muLogMacro(
-        << "Reading image " << atlasIndex + 1 << ": " << templateVolumes[atlasIndex] << "...\n");
+      muLogMacro(<< "Reading image " << atlasIndex + 1
+                 << ": " << templateVolumes[atlasIndex] << "...\n");
 
       ReaderPointer imgreader = ReaderType::New();
       imgreader->SetFileName( templateVolumes[atlasIndex].c_str() );
@@ -977,8 +973,8 @@ int main(int argc, char * *argv)
       || ( atlasToSubjectTransformType.compare("SyN") == 0 ) )
   )
     {
-    muLogMacro(
-      "ERROR:  Invalid atlasToSubjectTransformType specified" << atlasToSubjectTransformType << std::endl);
+    muLogMacro("ERROR:  Invalid atlasToSubjectTransformType specified"
+               << atlasToSubjectTransformType << std::endl);
     return EXIT_FAILURE;
     }
 
@@ -989,8 +985,8 @@ int main(int argc, char * *argv)
       || ( subjectIntermodeTransformType.compare("SyN") == 0 ) )
   )
     {
-    muLogMacro(
-      "ERROR:  Invalid subjectIntermodeTransformType specified" << subjectIntermodeTransformType << std::endl);
+    muLogMacro("ERROR:  Invalid subjectIntermodeTransformType specified"
+               << subjectIntermodeTransformType << std::endl);
     return EXIT_FAILURE;
     }
 
@@ -1071,7 +1067,7 @@ int main(int argc, char * *argv)
         else
           {
           itkGenericExceptionMacro( << "ERROR:  Invalid transform initializer type found:  "
-            << initialTransformFileType );
+                                    << initialTransformFileType );
           }
         }
       catch( itk::ExceptionObject & excp )
@@ -1084,8 +1080,8 @@ int main(int argc, char * *argv)
       }
     catch( itk::ExceptionObject & excp )
       {
-      muLogMacro(
-        "ERROR:  Invalid atlasToSubjectInitialTransform specified" << atlasToSubjectInitialTransform << std::endl);
+      muLogMacro("ERROR:  Invalid atlasToSubjectInitialTransform specified"
+                 << atlasToSubjectInitialTransform << std::endl);
       return EXIT_FAILURE;
       }
     }
@@ -1179,8 +1175,8 @@ int main(int argc, char * *argv)
     { // NOTE THIS IS REALLY ANNOYING FOR LARGE BSPLINE REGISTRATIONS!
     muLogMacro( << __FILE__ << " " << __LINE__ << " " <<
                 atlasToSubjectPreSegmentationTransform->GetFixedParameters() << std::endl );
-    muLogMacro(
-      << __FILE__ << " " << __LINE__ << " " << atlasToSubjectPreSegmentationTransform->GetParameters() << std::endl );
+    muLogMacro( << __FILE__ << " " << __LINE__ << " "
+                << atlasToSubjectPreSegmentationTransform->GetParameters() << std::endl );
     }
   if( debuglevel > 4 )
     {

--- a/BRAINSABC/brainseg/BRAINSABCUtilities.hxx
+++ b/BRAINSABC/brainseg/BRAINSABCUtilities.hxx
@@ -50,8 +50,9 @@ void NormalizeProbListInPlace(std::vector<typename TProbabilityImage::Pointer> &
           for( unsigned int iprior = 0; iprior < numProbs; iprior++ )
             {
             const FloatingPrecision & ProbListValue = ProbList[iprior]->GetPixel(currIndex); 
-            CHECK_NAN(ProbListValue, __FILE__, __LINE__, "\n  sumPrior: " << sumPrior << "\n  currIndex: " <<
-currIndex << "\n ProbListValue: " << ProbListValue << "\n  iprior: " << iprior );
+            CHECK_NAN(ProbListValue, __FILE__, __LINE__, "\n  sumPrior: " << sumPrior
+                      << "\n  currIndex: " << currIndex << "\n ProbListValue: "
+                      << ProbListValue << "\n  iprior: " << iprior );
             sumPrior += ProbListValue;
             }
           if( sumPrior < 1e-20 )
@@ -69,8 +70,11 @@ currIndex << "\n ProbListValue: " << ProbListValue << "\n  iprior: " << iprior )
               {
               const FloatingPrecision normValue = ProbList[iprior]->GetPixel(currIndex) * invSumPrior;
 
-              CHECK_NAN(normValue, __FILE__, __LINE__, "\n  sumPrior: " << sumPrior << "\n  iprior: " << iprior << "\n  currIndex: " <<
-currIndex << "\n probList: " << ProbList[iprior]->GetPixel(currIndex) << "\n  invSumPrior: " << invSumPrior );
+              CHECK_NAN(normValue, __FILE__, __LINE__, "\n  sumPrior: "
+                        << sumPrior << "\n  iprior: " << iprior << "\n  currIndex: "
+                        << currIndex << "\n probList: "
+                        << ProbList[iprior]->GetPixel(currIndex)
+                        << "\n  invSumPrior: " << invSumPrior );
               ProbList[iprior]->SetPixel(currIndex, normValue);
               }
             }

--- a/BRAINSABC/brainseg/BRAINSCleanMask.cxx
+++ b/BRAINSABC/brainseg/BRAINSCleanMask.cxx
@@ -27,8 +27,7 @@ int main(int argc, char * *argv)
     }
   catch( itk::ExceptionObject & e )
     {
-    std::cerr << "error reading " << inputVolume << std::endl
-              <<  e << std::endl;
+    std::cerr << "error reading " << inputVolume << std::endl <<  e << std::endl;
     return EXIT_FAILURE;
     }
   catch( ... )
@@ -48,8 +47,7 @@ int main(int argc, char * *argv)
     }
   catch( ... )
     {
-    std::cerr << "Error during processing of "
-              << inputVolume << std::endl;
+    std::cerr << "Error during processing of " << inputVolume << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -59,8 +57,7 @@ int main(int argc, char * *argv)
     }
   catch( itk::ExceptionObject & e )
     {
-    std::cerr << "error writing " << inputVolume << std::endl
-              <<  e << std::endl;
+    std::cerr << "error writing " << inputVolume << std::endl <<  e << std::endl;
     return EXIT_FAILURE;
     }
   catch( ... )

--- a/BRAINSABC/brainseg/ComputeDistributions.h
+++ b/BRAINSABC/brainseg/ComputeDistributions.h
@@ -209,8 +209,8 @@ CombinedComputeDistributions( const std::vector<typename ByteImageType::Pointer>
     {
     for( LOOPITERTYPE iclass = 0; iclass < (LOOPITERTYPE)numClasses; iclass++ )
       {
-      muLogMacro(
-        << "DEBUG USING NEW COVARIANCES: " << iclass << "\n" << ListOfClassStatistics[iclass].m_Covariance << std::endl );
+      muLogMacro(<< "DEBUG USING NEW COVARIANCES: " << iclass << std::endl
+                 << ListOfClassStatistics[iclass].m_Covariance << std::endl );
       }
     }
   if( DebugLevel > 9 )

--- a/BRAINSABC/brainseg/EMSParameters.cxx
+++ b/BRAINSABC/brainseg/EMSParameters.cxx
@@ -1,6 +1,7 @@
 #include "EMSParameters.h"
 
 #include "itksys/SystemTools.hxx"
+#include "DoubleToString.h"
 
 EMSParameters
 ::EMSParameters()
@@ -122,6 +123,8 @@ void
 EMSParameters
 ::PrintSelf(std::ostream & os, itk::Indent) const
 {
+  DoubleToString doubleConvert;
+
   os << "Suffix = " << m_Suffix << std::endl;
   os << "Atlas directory = " << m_AtlasDirectory << std::endl;
   os << "Atlas orientation = " << m_AtlasOrientation << std::endl;
@@ -133,7 +136,7 @@ EMSParameters
     os << "  " << m_Images[k] << " --- " << m_ImageOrientations[k] << std::endl;
     }
   os << "Filter iterations = " << m_FilterIterations << std::endl;
-  os << "Filter time step = " << m_FilterTimeStep << std::endl;
+  os << "Filter time step = " << doubleConvert(m_FilterTimeStep) << std::endl;
   os << "Max bias degree = " << m_MaxBiasDegree << std::endl;
   os << "Prior 1 = " << m_Prior1 << std::endl;
   os << "Prior 2 = " << m_Prior2 << std::endl;

--- a/BRAINSABC/brainseg/EMSegmentationFilter.hxx
+++ b/BRAINSABC/brainseg/EMSegmentationFilter.hxx
@@ -156,20 +156,23 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 
   if( m_WarpedPriors.size() != m_PriorWeights.size() )
     {
-    itkExceptionMacro(<< "The PriorWeights vector size must match the number of priors listed." << std::endl );
+    itkExceptionMacro(<< "The PriorWeights vector size must match the"
+                      << " number of priors listed." << std::endl );
     }
   if( m_WarpedPriors.size() != m_PriorLabelCodeVector.size() )
     {
-    itkExceptionMacro(<< "The PriorLabelCodeVector vector size must match the number of priors listed." << std::endl );
+    itkExceptionMacro(<< "The PriorLabelCodeVector vector size must match the"
+                      << " number of priors listed." << std::endl );
     }
   if( m_WarpedPriors.size() != m_PriorUseForBiasVector.size() )
     {
-    itkExceptionMacro(<< "The PriorUseForBiasVector vector size must match the number of priors listed." << std::endl );
+    itkExceptionMacro(<< "The PriorUseForBiasVector vector size must match the"
+                      << " number of priors listed." << std::endl );
     }
   if( m_WarpedPriors.size() != m_PriorIsForegroundPriorVector.size() )
     {
-    itkExceptionMacro(
-      << "The PriorIsForegroundPriorVector vector size must match the number of priors listed." << std::endl );
+    itkExceptionMacro(<< "The PriorIsForegroundPriorVector vector size"
+                      << " must match the number of priors listed." << std::endl );
     }
 
   if( m_MaximumIterations == 0 )
@@ -193,8 +196,8 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       const InputImageSizeType isize = m_InputImages[i]->GetLargestPossibleRegion().GetSize();
       if( size != isize )
         {
-        itkExceptionMacro(
-          << "Image data [" << i << "] 3D size mismatch " << size << " != " << isize << "." << std::endl );
+        itkExceptionMacro(<< "Image data [" << i << "] 3D size mismatch "
+                          << size << " != " << isize << "." << std::endl );
         }
       }
     for( unsigned i = 0; i < m_WarpedPriors.size(); i++ )
@@ -206,9 +209,9 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       const ProbabilityImageSizeType psize = m_WarpedPriors[i]->GetLargestPossibleRegion().GetSize();
       if( size != psize )
         {
-        itkExceptionMacro(
-          << "Warped prior [" << i << "] and atlas data 3D size mismatch" << size << " != " << psize << "."
-          << std::endl );
+        itkExceptionMacro(<< "Warped prior [" << i << "] and atlas data 3D size mismatch"
+                          << size << " != " << psize << "."
+                          << std::endl );
         }
       }
     }
@@ -224,8 +227,8 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       const InputImageSizeType asize = m_OriginalAtlasImages[i]->GetLargestPossibleRegion().GetSize();
       if( atlasSize != asize )
         {
-        itkExceptionMacro(
-          << "Image data [" << i << "] 3D size mismatch " << atlasSize << " != " << asize << "." << std::endl );
+        itkExceptionMacro(<< "Image data [" << i << "] 3D size mismatch "
+                          << atlasSize << " != " << asize << "." << std::endl );
         }
       }
     for( unsigned i = 0; i < m_OriginalSpacePriors.size(); i++ )
@@ -237,9 +240,9 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
       const ProbabilityImageSizeType psize = m_OriginalSpacePriors[i]->GetLargestPossibleRegion().GetSize();
       if( atlasSize != psize )
         {
-        itkExceptionMacro(
-          << "Normalized prior [" << i << "] and atlas 3D size mismatch" << atlasSize << " != " << psize << "."
-          << std::endl );
+        itkExceptionMacro(<< "Normalized prior [" << i << "] and atlas 3D size mismatch"
+                          << atlasSize << " != " << psize << "."
+                          << std::endl );
         }
       }
     }
@@ -316,7 +319,7 @@ void EMSegmentationFilter<TInputImage, TProbabilityImage>
                                                                     // debugging
                                                                     // purposes
                                                                     // only;
-    std::stringstream write_posteriors_level_stream("");
+    std::stringstream write_posteriors_level_stream;
     write_posteriors_level_stream << write_posteriors_level;
     for( unsigned int iprob = 0; iprob < numPosteriors; iprob++ )
       {
@@ -583,15 +586,14 @@ static double ComputeCovarianceDeterminant( const vnl_matrix<FloatingPrecision> 
 
   if( detcov <= 0.0 )
     {
-    itkGenericExceptionMacro(
-      << "Determinant of covariance "
-      << " is <= 0.0 (" << detcov << "), covariance matrix:" << std::endl
-      << currCovariance
-      <<
-      "\n\n\n This is indicative of providing two images that are related only through a linear depenancy\n"
-      <<
-      "at least two images are so close in their ratio of values that a degenerate covariance matrix\n"
-      << "would result, thus making an unstable calculation\n\n\n");
+    itkGenericExceptionMacro(<< "Determinant of covariance "
+                             << " is <= 0.0 (" << detcov << "), covariance matrix:"
+                             << std::endl << currCovariance
+                             << "\n\n\n This is indicative of providing two images"
+                             <<" that are related only through a linear depenancy\n"
+                             << "at least two images are so close in their ratio of"
+                             <<" values that a degenerate covariance matrix\n"
+                             << "would result, thus making an unstable calculation\n\n\n");
     }
   return detcov;
 }
@@ -675,11 +677,12 @@ ComputeOnePosterior(
             const typename TProbabilityImage::PixelType currentPosterior =
               static_cast<typename TProbabilityImage::PixelType>( (priorScale * priorValue * likelihood) );
             CHECK_NAN(currentPosterior, __FILE__, __LINE__, "\n  currIndex: " << currIndex
-                  << "\n  priorScale: " << priorScale << "\n  priorValue: " << priorValue << "\n  likelihood: " << likelihood
-                  << "\n  mahalo: " << mahalo
-                  << "\n  invcov: " << invcov
-                  << "\n  X:  " << X
-                  << "\n  Y:  " << Y );
+                      << "\n  priorScale: " << priorScale << "\n  priorValue: " << priorValue
+                      << "\n  likelihood: " << likelihood
+                      << "\n  mahalo: " << mahalo
+                      << "\n  invcov: " << invcov
+                      << "\n  X:  " << X
+                      << "\n  Y:  " << Y );
             post->SetPixel(currIndex, currentPosterior);
             }
           }
@@ -1034,9 +1037,9 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
         const std::string priorType = this->m_PriorNames[i];
         if( m_TissueTypeThresholdMapsRange[priorType].find(imageType) == m_TissueTypeThresholdMapsRange[priorType].end() )
           {
-          muLogMacro(
-            << "NOT FOUND:" << "[" << priorType << "," << imageType << "]: [" << 0.00 << "," << 1.00 << "]"
-            <<  std::endl);
+          muLogMacro(<< "NOT FOUND:" << "[" << priorType << "," << imageType
+                     << "]: [" << 0.00 << "," << 1.00 << "]"
+                     <<  std::endl);
           QuantileLowerThreshold.SetElement(modeIndex, 0.00);
           QuantileUpperThreshold.SetElement(modeIndex, 1.00);
           }
@@ -1426,9 +1429,9 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
         // --AtlasTransformType [Rigid|Affine|BSpline|SyN], defaults to SyN.
         if( m_AtlasTransformType == "Rigid" )
           {
-          muLogMacro(
-            << "Registering (Rigid) " << preprocessMovingString << "atlas(" << vIndex << ") to template(" << vIndex
-            << ") image." << std::endl);
+          muLogMacro(<< "Registering (Rigid) " << preprocessMovingString << "atlas("
+                     << vIndex << ") to template(" << vIndex
+                     << ") image." << std::endl);
           std::vector<double> minimumStepSize(1);
           minimumStepSize[0] = 0.005; // NOTE: 0.005 for between subject
                                       // registration is probably about the
@@ -1452,9 +1455,9 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
           }
         else if( m_AtlasTransformType == "BSpline" )
           {
-          muLogMacro(
-            << "Registering (BSpline) " << preprocessMovingString << "atlas(" << vIndex << ") to template(" << vIndex
-            << ") image." << std::endl);
+          muLogMacro(<< "Registering (BSpline) " << preprocessMovingString << "atlas("
+                     << vIndex << ") to template(" << vIndex
+                     << ") image." << std::endl);
           std::vector<double> minimumStepSize(1);
           minimumStepSize[0] = 0.0025;
           atlasToSubjectRegistrationHelper->SetMinimumStepLength(minimumStepSize);

--- a/BRAINSABC/brainseg/EMSplitPriorMST.h
+++ b/BRAINSABC/brainseg/EMSplitPriorMST.h
@@ -376,8 +376,7 @@ EMSegmentationFilter<TInputImage, TProbabilityImage>
 
     if( imin != ( numClasses - 1 ) )
       {
-      muLogMacro(
-        << "  Replacing " << this->m_ListOfClassStatistics[imin].m_Means << " with zero\n");
+      muLogMacro(<< "  Replacing " << this->m_ListOfClassStatistics[imin].m_Means << " with zero\n");
       VectorType v = this->m_ListOfClassStatistics[numClasses - 1].m_Means;
       this->m_ListOfClassStatistics[imin].m_Means = v;
       }

--- a/BRAINSABC/brainseg/LLSBiasCorrector.hxx
+++ b/BRAINSABC/brainseg/LLSBiasCorrector.hxx
@@ -660,14 +660,12 @@ LLSBiasCorrector<TInputImage, TProbabilityImage>
     if( coeffs[0][0] != std::numeric_limits::infinity() )
 #endif
     {
-    itkExceptionMacro(
-      << "\ncoeffs: \n" << coeffs
-      // << "\nlhs_ij: \n" << lhs_ij
-      << "\nbasisT: \n" << basisT
-      // << "\nWij_A: \n" << Wij_A
-      << "\nlhs: \n" << lhs
-      << "\nrhs: \n" << rhs
-      );
+    itkExceptionMacro(<< "\ncoeffs: \n" << coeffs
+                      // << "\nlhs_ij: \n" << lhs_ij
+                      << "\nbasisT: \n" << basisT
+                      // << "\nWij_A: \n" << Wij_A
+                      << "\nlhs: \n" << lhs
+                      << "\nrhs: \n" << rhs);
     }
   // Clear memory for the basis transpose
   basisT.set_size(0, 0);

--- a/BRAINSABC/common/Log.cxx
+++ b/BRAINSABC/common/Log.cxx
@@ -57,8 +57,7 @@ Log
 
   if( m_Output.fail() )
     {
-    muExceptionMacro(
-      << "[Log::SetOutputFileName] Failed to open " << s);
+    muExceptionMacro(<< "[Log::SetOutputFileName] Failed to open " << s);
     }
 }
 

--- a/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
+++ b/BRAINSCommonLib/BRAINSFitHelperTemplate.hxx
@@ -992,23 +992,20 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           // transformFileType
           // == "ScaleVersor3DTransform"
             {
-            std::cout
-            <<
-            "Unsupported initial transform file -- TransformBase first transform typestring, "
-            << transformFileType
-            << " not equal to required type VersorRigid3DTransform "
-            << "OR ScaleVersor3DTransform OR ScaleSkewVersor3DTransform"
-            << std::endl;
+            std::cout << "Unsupported initial transform file -- TransformBase first transform typestring, "
+                      << transformFileType
+                      << " not equal to required type VersorRigid3DTransform "
+                      << "OR ScaleVersor3DTransform OR ScaleSkewVersor3DTransform"
+                      << std::endl;
             return;
             }
           }
         catch( itk::ExceptionObject & excp )
           {
           std::cout << "[FAILED]" << std::endl;
-          std::cerr
-          << "Error while reading the m_CurrentGenericTransform"
-          << std::endl;
-          std::cerr << excp << std::endl;
+          std::cerr << "Error while reading the m_CurrentGenericTransform"
+                    << std::endl
+                    << excp << std::endl;
 	  throw;
           }
         }
@@ -1097,8 +1094,7 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           else              //  NO SUCH CASE!!
             {
             std::cout
-            <<
-            "Unsupported initial transform file -- TransformBase first transform typestring, "
+            << "Unsupported initial transform file -- TransformBase first transform typestring, "
             << transformFileType
             << " not equal to any recognized type VersorRigid3DTransform OR "
             << "ScaleVersor3DTransform OR ScaleSkewVersor3DTransform OR AffineTransform"
@@ -1109,10 +1105,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
         catch( itk::ExceptionObject & excp )
           {
           std::cout << "[FAILED]" << std::endl;
-          std::cerr
-          << "Error while reading the m_CurrentGenericTransform"
-          << std::endl;
-          std::cerr << excp << std::endl;
+          std::cerr << "Error while reading the m_CurrentGenericTransform"
+                    << std::endl << excp << std::endl;
           throw;
           }
         }
@@ -1538,10 +1532,8 @@ BRAINSFitHelperTemplate<FixedImageType, MovingImageType>::Update(void)
           catch( itk::ExceptionObject & excp )
           {
               std::cout << "[FAILED]" << std::endl;
-              std::cerr
-              << "Error while reading the m_CurrentGenericTransform"
-              << std::endl;
-              std::cerr << excp << std::endl;
+              std::cerr << "Error while reading the m_CurrentGenericTransform"
+                        << std::endl << excp << std::endl;
 	      throw;
           }
       }

--- a/BRAINSCommonLib/CMakeLists.txt
+++ b/BRAINSCommonLib/CMakeLists.txt
@@ -21,11 +21,12 @@ set(BRAINSCommonLib_SRCS
   itkOrthogonalize3DRotationMatrix.cxx
   BRAINSThreadControl.cxx
   ExtractSingleLargestRegion.cxx
+  DoubleToString.cxx
 )
 
 ## Always build BRAINSCommonLib as static
 add_library(BRAINSCommonLib STATIC ${BRAINSCommonLib_SRCS})
-target_link_libraries(BRAINSCommonLib ${ITK_LIBRARIES} ${ANTS_LIBS})
+target_link_libraries(BRAINSCommonLib ${ITK_LIBRARIES} ${ANTS_LIBS} ${double-conversion_LIBRARIES})
 
 install(TARGETS BRAINSCommonLib
   RUNTIME DESTINATION ${BRAINSTools_CLI_INSTALL_RUNTIME_DESTINATION} COMPONENT RuntimeLibraries

--- a/BRAINSCommonLib/ConvertToRigidAffine.h
+++ b/BRAINSCommonLib/ConvertToRigidAffine.h
@@ -63,10 +63,9 @@ AssignConvertedTransform(AffineTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, while assigning AffineTransformPointer := AffineTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, while assigning "
+              << "AffineTransformPointer := AffineTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -98,10 +97,9 @@ AssignConvertedTransform(AffineTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, while assigning AffineTransformPointer := VnlTransformMatrixType44."
-    << std::endl;
+    std::cout << "Error missing Pointer data, while assigning "
+              << "AffineTransformPointer := VnlTransformMatrixType44."
+              << std::endl;
     throw;
     }
 }
@@ -130,10 +128,9 @@ AssignConvertedTransform(VnlTransformMatrixType44 & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, while assigning VnlTransformMatrixType44 := AffineTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, while assigning"
+              << " VnlTransformMatrixType44 := AffineTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -154,10 +151,9 @@ AssignConvertedTransform(AffineTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning AffineTransformPointer := ScaleSkewVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning AffineTransformPointer"
+              << " := ScaleSkewVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -176,10 +172,9 @@ AssignConvertedTransform(ScaleSkewVersor3DTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning AffineTransformPointer := ScaleSkewVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning AffineTransformPointer "
+              << ":= ScaleSkewVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -203,10 +198,9 @@ AssignConvertedTransform(AffineTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning AffineTransformPointer := ScaleVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning AffineTransformPointer"
+              << " := ScaleVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -226,10 +220,9 @@ AssignConvertedTransform(ScaleVersor3DTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning ScaleVersor3DTransform := ScaleVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning ScaleVersor3DTransform"
+              << " := ScaleVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -254,10 +247,9 @@ AssignConvertedTransform(AffineTransformPointer & result,
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning AffineTransformPointer := VersorRigid3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning AffineTransformPointer"
+              << " := VersorRigid3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -277,10 +269,9 @@ inline void AssignConvertedTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning VersorRigid3DTransformPointer := VersorRigid3DTTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " VersorRigid3DTransformPointer := VersorRigid3DTTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -302,10 +293,9 @@ inline void AssignConvertedTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning ScaleSkewVersor3DTransformPointer := ScaleVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " ScaleSkewVersor3DTransformPointer := ScaleVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -326,10 +316,9 @@ inline void AssignConvertedTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning ScaleSkewVersor3DTransformPointer := VersorRigid3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " ScaleSkewVersor3DTransformPointer := VersorRigid3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -350,10 +339,9 @@ inline void AssignConvertedTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning ScaleVersor3DTransformPointer := VersorRigid3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " ScaleVersor3DTransformPointer := VersorRigid3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -371,10 +359,9 @@ inline void ExtractVersorRigid3DTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning VersorRigid3DTransformPointer := ScaleVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " VersorRigid3DTransformPointer := ScaleVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -392,10 +379,9 @@ inline void ExtractVersorRigid3DTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning VersorRigid3DTransformPointer := ScaleSkewVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " VersorRigid3DTransformPointer := ScaleSkewVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }
@@ -411,10 +397,9 @@ inline void ExtractVersorRigid3DTransform(
     }
   else
     {
-    std::cout
-    <<
-    "Error missing Pointer data, assigning VersorRigid3DTransformPointer := ScaleVersor3DTransformPointer."
-    << std::endl;
+    std::cout << "Error missing Pointer data, assigning"
+              << " VersorRigid3DTransformPointer := ScaleVersor3DTransformPointer."
+              << std::endl;
     throw;
     }
 }

--- a/BRAINSCommonLib/CreateField.hxx
+++ b/BRAINSCommonLib/CreateField.hxx
@@ -119,8 +119,7 @@ void CreateField<TImage,
       {
       if( fscanf(paramFile, "%d", &uNumber) != 1 )
         {
-        itkExceptionMacro(
-          << "  Could not find subject starting shrink factor. ");
+        itkExceptionMacro(<< "  Could not find subject starting shrink factor. ");
         }
       m_Image2ShrinkFactors[j] = uNumber;
       }
@@ -180,13 +179,12 @@ void CreateField<TImage,
           != itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RIP )
         )
       {
-      std::cout
-      << "Image Directions are not the same or are not in RIP orientation "
-      << std::endl
-      << m_FixedImage->GetDirection()
-      << "=============" << std::endl
-      << m_MovingImage->GetDirection()
-      << std::endl;
+      std::cout << "Image Directions are not the same or are not in RIP orientation "
+                << std::endl
+                << m_FixedImage->GetDirection()
+                << "=============" << std::endl
+                << m_MovingImage->GetDirection()
+                << std::endl;
       }
     m_ImageOne = NULL;
     m_ImageTwo = NULL;

--- a/BRAINSCommonLib/DoubleToString.cxx
+++ b/BRAINSCommonLib/DoubleToString.cxx
@@ -1,0 +1,21 @@
+#include "DoubleToString.h"
+
+DoubleToString
+::DoubleToString() :
+  m_DoubleToStringConverter(double_conversion::DoubleToStringConverter::EcmaScriptConverter())
+{
+}
+
+std::string
+DoubleToString
+::operator()(double val)
+{
+  char buf[256];
+  double_conversion::StringBuilder builder(buf,sizeof(buf));
+  builder.Reset();
+  if(!m_DoubleToStringConverter.ToShortest(val,&builder))
+    {
+    itkGenericExceptionMacro(<< "Conversion failed for " << val);
+    }
+  return std::string(builder.Finalize());
+}

--- a/BRAINSCommonLib/DoubleToString.h
+++ b/BRAINSCommonLib/DoubleToString.h
@@ -3,25 +3,15 @@
 
 #include "double-conversion.h"
 #include "itkMacro.h"
+
 class DoubleToString
 {
 public:
-  DoubleToString() :
-    m_DoubleToStringConverter(double_conversion::DoubleToStringConverter::EcmaScriptConverter())
-    {
-    }
-  std::string operator()(double val)
-    {
-      char buf[256];
-      double_conversion::StringBuilder builder(buf,sizeof(buf));
-      builder.Reset();
-      if(!m_DoubleToStringConverter.ToShortest(val,&builder))
-        {
-        itkGenericExceptionMacro(<< "Conversion failed for " << val);
-        }
-      return std::string(builder.Finalize());
-    }
+  DoubleToString();
+  std::string operator()(double val);
 private:
+  DoubleToString & operator=(const DoubleToString &); // not defined
   const double_conversion::DoubleToStringConverter &m_DoubleToStringConverter;
 };
+
 #endif // DoubleToString_h

--- a/BRAINSCommonLib/GenericTransformImage.cxx
+++ b/BRAINSCommonLib/GenericTransformImage.cxx
@@ -190,8 +190,8 @@ int WriteBothTransformsToDisk(const GenericTransformType::ConstPointer genericTr
       {
       std::cout << "Unsupported initial transform file -- TransformBase first transform typestring, "
                 << transformFileType
-                <<
-      " not equal to any recognized type VersorRigid3DTransform OR ScaleVersor3DTransform OR ScaleSkewVersor3DTransform OR AffineTransform"
+                << " not equal to any recognized type VersorRigid3DTransform OR"
+                << " ScaleVersor3DTransform OR ScaleSkewVersor3DTransform OR AffineTransform"
                 << std::endl;
       return -1;
       }
@@ -244,9 +244,10 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
 	      if( currentTransformList.size() == 0 )
 	        {
 	        itkGenericExceptionMacro( << "Number of currentTransformList = " << currentTransformList.size()
-	          << "FATAL ERROR: Failed to read transform" << initialTransform);
+                                          << "FATAL ERROR: Failed to read transform" << initialTransform);
 	        }
-        std::cout << "HACK: " << currentTransformList.size() << "  " << ( *( currentTransformList.begin() ) )->GetNameOfClass() << std::endl;
+              std::cout << "HACK: " << currentTransformList.size() << "  "
+                        << ( *( currentTransformList.begin() ) )->GetNameOfClass() << std::endl;
 	      }
       }
     catch( itk::ExceptionObject & excp )
@@ -427,12 +428,11 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
     else
       {
       std::cout << "[FAILED]" << std::endl;
-      std::cerr
-      << "Error using the currentTransformList has two elements, but neither of them are a BSplineDeformableTransform/"
-      << std::endl;
-      std::cerr
-      << "There should not be more than two transforms in the transform list."
-      << std::endl;
+      std::cerr << "Error using the currentTransformList has two elements, but"
+                << " neither of them are a BSplineDeformableTransform/"
+                << std::endl
+                << "There should not be more than two transforms in the transform list."
+                << std::endl;
       return NULL;
       }
     genericTransform = outputBSplineTransform.GetPointer();
@@ -441,12 +441,11 @@ GenericTransformType::Pointer ReadTransformFromDisk(const std::string & initialT
     {
     // Error, too many transforms on transform list.
     std::cout << "[FAILED]" << std::endl;
-    std::cerr
-    << "Error using the currentTransformList for initializing a BSPlineDeformableTransform:"
-    << std::endl;
-    std::cerr
-    << "There should not be more than two transforms in the transform list."
-    << std::endl;
+    std::cerr << "Error using the currentTransformList for initializing a"
+              << " BSPlineDeformableTransform:"
+              << std::endl
+              << "There should not be more than two transforms in the transform list."
+              << std::endl;
     return NULL;
     }
   return genericTransform;

--- a/BRAINSCommonLib/Slicer3LandmarkIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkIO.cxx
@@ -5,11 +5,12 @@
  */
 
 #include "Slicer3LandmarkIO.h"
-
+#include "DoubleToString.h"
 void
 WriteITKtoSlicer3Lmk( const std::string & landmarksFilename,
                       const LandmarksMapType & landmarks )
 {
+  DoubleToString doubleConvert;
   const std::string fullPathLandmarksFileName = itksys::SystemTools::CollapseFullPath( landmarksFilename.c_str() );
 
   std::stringstream lmkPointStream;
@@ -23,9 +24,9 @@ WriteITKtoSlicer3Lmk( const std::string & landmarksFilename,
       // but ITK landmarks are in LPS, so we need to negate the first two
       // component of the landmark points.
       lmkPointStream <<     it->first       << ","
-                     << -( it->second[0] ) << ","
-                     << -( it->second[1] ) << ","
-                     << +( it->second[2] )
+                     << doubleConvert(-( it->second[0] )) << ","
+                     << doubleConvert(-( it->second[1] )) << ","
+                     << doubleConvert(+( it->second[2] ))
                      << ",1,1\n"; // Note the last two columns are
                                   // ,visible,editable
       ++numNamedLandmarks;

--- a/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
+++ b/BRAINSCommonLib/Slicer3LandmarkWeightIO.cxx
@@ -2,16 +2,18 @@
  * Author: Ali Ghayoor, Wei Lu
  * at Psychiatry Imaging Lab,
  * University of Iowa Health Care 2011
-  
  */
 
 #include "Slicer3LandmarkWeightIO.h"
-
+#include "DoubleToString.h"
 void
 WriteITKtoSlicer3LmkWts( const std::string & landmarksWeightFilename,
                       const LandmarksWeightMapType & landmarks )
 {
-  const std::string fullPathLandmarksWeightFileName = itksys::SystemTools::CollapseFullPath( landmarksWeightFilename.c_str() );
+  DoubleToString doubleConvert;
+
+  const std::string fullPathLandmarksWeightFileName =
+    itksys::SystemTools::CollapseFullPath( landmarksWeightFilename.c_str() );
 
   std::stringstream lmkWeightStream;
 
@@ -21,8 +23,8 @@ WriteITKtoSlicer3LmkWts( const std::string & landmarksWeightFilename,
     if( ( it->first ).compare("") != 0 )
       {
       lmkWeightStream << it->first << ","
-		              << it->second << std::endl;
-                     
+                      << doubleConvert(it->second) << std::endl;
+
       ++numNamedLandmarks;
       }
     }
@@ -76,7 +78,7 @@ ReadSlicer3toITKLmkWts( const std::string & landmarksWeightFilename )
       double            weight;
 	  const size_t pos2 = line.find( ' ', pos1 + 1 );
       weight = atof( line.substr(pos1 + 1, pos2 - pos1 - 1 ).c_str() );
-        
+
       landmarks[name] = weight;
       }
     }

--- a/BRAINSCommonLib/TestSuite/CMakeLists.txt
+++ b/BRAINSCommonLib/TestSuite/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_executable(PrettyPrintTableTest PrettyPrintTableTest.cxx)
-target_link_libraries(PrettyPrintTableTest ${double-conversion_LIBRARIES} ${ITK_LIBRARIES} )
+target_link_libraries(PrettyPrintTableTest BRAINSCommonLib)
 
 set_target_properties(PrettyPrintTableTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testbin)
 

--- a/BRAINSCommonLib/TestSuite/FindCenterOfBrain.cxx
+++ b/BRAINSCommonLib/TestSuite/FindCenterOfBrain.cxx
@@ -14,6 +14,7 @@
 #include "itkFindCenterOfBrainFilter.h"
 #include "itkIO.h"
 #include <FindCenterOfBrainCLP.h>
+#include "DoubleToString.h"
 
 int main(int argc, char * *argv)
 {
@@ -70,10 +71,11 @@ int main(int argc, char * *argv)
     }
   FindCenterFilterType::PointType center =
     filter->GetCenterOfBrain();
+  DoubleToString doubleConvert;
   std::cout << "Center Of Brain:"
-            << " " << center[0]
-            << " " << center[1]
-            << " " << center[2]
+            << " " << doubleConvert(center[0])
+            << " " << doubleConvert(center[1])
+            << " " << doubleConvert(center[2])
             << std::endl;
   if( ClippedImageMask != "" )
     {

--- a/BRAINSCommonLib/genericRegistrationHelper.hxx
+++ b/BRAINSCommonLib/genericRegistrationHelper.hxx
@@ -174,9 +174,9 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
   if( ( m_PermitParameterVariation.size() != m_Transform->GetNumberOfParameters() )
       && ( m_PermitParameterVariation.size() != 0 ) )
     {
-    std::cout
-    << "WARNING:  The permit parameters SHOULD match the number of parameters used for this registration type."
-    << std::endl;
+    std::cout << "WARNING:  The permit parameters SHOULD match the number of"
+              << " parameters used for this registration type."
+              << std::endl;
     std::cout << "WARNING:  Padding with 1's for the unspecified parameters" << std::endl;
     std::cout << "m_PermitParameterVariation " << m_PermitParameterVariation.size() << " != "
               << m_Transform->GetNumberOfParameters() << std::endl;
@@ -205,8 +205,8 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
     }
   else      // Won't happen under BRAINSFitPrimary.
     {
-    itkGenericExceptionMacro(
-      << "FAILURE:  InitialTransform must be set in MultiModal3DMutualRegistrationHelper before Initialize is called.");
+    itkGenericExceptionMacro(<< "FAILURE:  InitialTransform must be set in"
+                             << " MultiModal3DMutualRegistrationHelper before Initialize is called.");
     //  m_Transform would be SetIdentity() if this case continued.
     }
 
@@ -306,10 +306,10 @@ MultiModal3DMutualRegistrationHelper<TTransformType, TOptimizer, TFixedImage,
   optimizer->SetNumberOfIterations(m_NumberOfIterations);
 
   //std::cout << "OPTIMIZER    THREADS USED: " << optimizer->GetNumberOfThreads()                << std::endl;
-  std::cout << "METRIC       THREADS USED: " << this->m_CostMetricObject->GetNumberOfThreads() <<
-   " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
-  std::cout << "REGISTRATION THREADS USED: " << this->m_Registration->GetNumberOfThreads()     <<
-   " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
+  std::cout << "METRIC       THREADS USED: " << this->m_CostMetricObject->GetNumberOfThreads()
+            << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
+  std::cout << "REGISTRATION THREADS USED: " << this->m_Registration->GetNumberOfThreads()
+            << " of " << itk::MultiThreader::GetGlobalDefaultNumberOfThreads() <<  std::endl;
 
 #if 0
   // if (globalVerbose)

--- a/BRAINSCommonLib/itkComputeHistogramQuantileThresholds.hxx
+++ b/BRAINSCommonLib/itkComputeHistogramQuantileThresholds.hxx
@@ -122,9 +122,8 @@ ComputeHistogramQuantileThresholds<TInputImage, TMaskImage>
 
     if( m_NumberOfValidHistogramsEntries <= 2 )  // then it is a binary image:
       {
-      std::cout
-      << "Image handled with only two catgegories; effectively, binary thresholding."
-      << std::endl;
+      std::cout << "Image handled with only two catgegories; effectively, binary thresholding."
+                << std::endl;
       }
     else
       {
@@ -134,22 +133,19 @@ ComputeHistogramQuantileThresholds<TInputImage, TMaskImage>
       m_UpperIntensityThresholdValue =
         static_cast<typename TInputImage::PixelType>
         ( histogram->Quantile(0, this->m_QuantileUpperThreshold) );
-      std::cout
-      << m_NumberOfValidHistogramsEntries
-      << " ValidHistogramsEntries,  "
-      << histogram->GetTotalFrequency()
-      << " TotalFrequency"
-      << std::endl;
-      std::cout
-      << m_QuantileLowerThreshold
-      << " ---> "
-      << static_cast<int>( m_LowerIntensityThresholdValue )
-      << std::endl;
-      std::cout
-      << m_QuantileUpperThreshold
-      << " ---> "
-      << static_cast<int>( m_UpperIntensityThresholdValue )
-      << std::endl;
+      std::cout << m_NumberOfValidHistogramsEntries
+                << " ValidHistogramsEntries,  "
+                << histogram->GetTotalFrequency()
+                << " TotalFrequency"
+                << std::endl
+                << m_QuantileLowerThreshold
+                << " ---> "
+                << static_cast<int>( m_LowerIntensityThresholdValue )
+                << std::endl
+                << m_QuantileUpperThreshold
+                << " ---> "
+                << static_cast<int>( m_UpperIntensityThresholdValue )
+                << std::endl;
       }
     }
   return;

--- a/BRAINSCommonLib/itkDiffusionTensor3DReconstructionWithMaskImageFilter.hxx
+++ b/BRAINSCommonLib/itkDiffusionTensor3DReconstructionWithMaskImageFilter.hxx
@@ -74,9 +74,8 @@ void DiffusionTensor3DReconstructionWithMaskImageFilter<TReferenceImagePixelType
       this->ProcessObject::GetInput(0)->GetNameOfClass() );
     if( strcmp(gradientImageClassName.c_str(), "VectorImage") != 0 )
       {
-      itkExceptionMacro(
-        << "There is only one Gradient image. I expect that to be a VectorImage. "
-        << "But its of type: " << gradientImageClassName );
+      itkExceptionMacro(<< "There is only one Gradient image. I expect that to be a VectorImage. "
+                        << "But its of type: " << gradientImageClassName );
       }
     }
   if( this->m_MaskImage.IsNotNull() )

--- a/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
+++ b/BRAINSCommonLib/itkInverseConsistentLandmarks.hxx
@@ -1248,34 +1248,26 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
   bool sizematch = true;
   if( this->getXDim() != newlmks.getXDim() )
     {
-    std::cout
-    <<
-    "Error. X dimensions of landmark objects do not match in ConcatLandmarks!"
-    << std::endl;
+    std::cout << "Error. X dimensions of landmark objects do not match in ConcatLandmarks!"
+              << std::endl;
     sizematch = false;
     }
   if( this->getYDim() != newlmks.getYDim() )
     {
-    std::cout
-    <<
-    "Error. Y dimensions of landmark objects do not match in ConcatLandmarks!"
-    << std::endl;
+    std::cout << "Error. Y dimensions of landmark objects do not match in ConcatLandmarks!"
+              << std::endl;
     sizematch = false;
     }
   if( this->getZDim() != newlmks.getZDim() )
     {
-    std::cout
-    <<
-    "Error. Z dimensions of landmark objects do not match in ConcatLandmarks!"
-    << std::endl;
+    std::cout << "Error. Z dimensions of landmark objects do not match in ConcatLandmarks!"
+              << std::endl;
     sizematch = false;
     }
   if( this->getTDim() != newlmks.getTDim() )
     {
-    std::cout
-    <<
-    "Error. T dimensions of landmark objects do not match in ConcatLandmarks!"
-    << std::endl;
+    std::cout << "Error. T dimensions of landmark objects do not match in ConcatLandmarks!"
+              << std::endl;
     sizematch = false;
     }
   if( sizematch == false )
@@ -1501,8 +1493,7 @@ bool InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      << "ERROR: End of file reached before LANDMARK_HEADER_BEGIN found"
+      std::cout << "ERROR: End of file reached before LANDMARK_HEADER_BEGIN found"
       << std::endl;
       }
     }
@@ -1553,9 +1544,8 @@ bool InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      << "ERROR: End of file reached before LANDMARK_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before LANDMARK_HEADER_END found"
+                << std::endl;
       }
     }
 
@@ -1740,10 +1730,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     // std::cout << "LINE: " << buffer << std::endl;
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_BEGIN found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_BEGIN found"
+                << std::endl;
       }
     }
 
@@ -1795,10 +1783,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     // }
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     }
 
@@ -1829,10 +1815,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("AC_Point", buffer, ImageDims, ImageRes,
                           AC_Point) == false )
@@ -1844,10 +1828,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("PC_Point", buffer, ImageDims, ImageRes,
                           PC_Point) == false )
@@ -1859,10 +1841,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("SLAPoint", buffer, ImageDims, ImageRes,
                           SLAPoint) == false )
@@ -1874,10 +1854,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("IRPPoint", buffer, ImageDims, ImageRes,
                           IRPPoint) == false )
@@ -2108,10 +2086,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_BEGIN found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_BEGIN found"
+                << std::endl;
       }
     }
 
@@ -2149,10 +2125,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     // }
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     }
 
@@ -2182,10 +2156,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("SLAPoint", buffer, ImageDims, ImageRes,
                           SLAPoint) == false )
@@ -2197,10 +2169,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
       status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
       if( status == NULL )
         {
-        std::cout
-        <<
-        "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-        << std::endl;
+        std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                  << std::endl;
         }
       // if(process_bnd_point("AC_Point", buffer, ImageDims, ImageRes,
       // AC_Point)==false) {return false;}
@@ -2210,10 +2180,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("FV_Point", buffer, ImageDims, ImageRes,
                           FV_Point) == false )
@@ -2225,10 +2193,8 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     status = fgets(buffer, FILE_BUFFER_SIZE, tempfile);
     if( status == NULL )
       {
-      std::cout
-      <<
-      "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
-      << std::endl;
+      std::cout << "ERROR: End of file reached before TALAIRACH_PARAMETER_HEADER_END found"
+                << std::endl;
       }
     if( process_bnd_point("IRPPoint", buffer, ImageDims, ImageRes,
                           IRPPoint) == false )
@@ -2339,7 +2305,7 @@ InverseConsistentLandmarks<PointStorageType, PointSetType>
     }
 }
 
-template <typename PointStorageType, typename PointSetType>
+template typename PointStorageType, typename PointSetType>
 bool
 InverseConsistentLandmarks<PointStorageType, PointSetType>
 ::ReadIPLCerebellarPointTypes(const std::string lmrkfilename,

--- a/BRAINSCommonLib/itkLargestForegroundFilledMaskImageFilter.hxx
+++ b/BRAINSCommonLib/itkLargestForegroundFilledMaskImageFilter.hxx
@@ -98,17 +98,18 @@ LargestForegroundFilledMaskImageFilter<TInputImage, TOutputImage>
       }
     if( this->m_OtsuPercentileUpperThreshold > 1.5 )
       {
-      itkExceptionMacro(
-        << "To save the day, PRETENDING an apparently mistaken histogram-trimming"
-        " threshold >= 1.5 really indicates number of histogram bins"
-        " (3.5 rounds up and indicates quartiles, etc.):  "
-        << this->m_OtsuPercentileLowerThreshold << " " <<  this->m_OtsuPercentileUpperThreshold << " ");
+      itkExceptionMacro(<< "To save the day, PRETENDING an apparently mistaken histogram-trimming"
+                        " threshold >= 1.5 really indicates number of histogram bins"
+                        " (3.5 rounds up and indicates quartiles, etc.):  "
+                        << this->m_OtsuPercentileLowerThreshold << " "
+                        <<  this->m_OtsuPercentileUpperThreshold << " ");
       }
     if( this->m_OtsuPercentileLowerThreshold > 0.5  || this->m_OtsuPercentileUpperThreshold < 0.5 )
       {
       itkExceptionMacro(<< "Trimming back worthless PercentileThreshold"
                         " over the two-tailed maximum of 0.5:  "
-                        << this->m_OtsuPercentileLowerThreshold << " " <<  this->m_OtsuPercentileUpperThreshold << " ");
+                        << this->m_OtsuPercentileLowerThreshold << " "
+                        << this->m_OtsuPercentileUpperThreshold << " ");
       }
     }
   this->AllocateOutputs();
@@ -235,9 +236,9 @@ LargestForegroundFilledMaskImageFilter<TInputImage, TOutputImage>
         std::cout << "WARNING:  Attempting to close with a very large number of voxels:  "
                   << m_ClosingSize << " / " << ( relabel->GetOutput()->GetSpacing()[d] ) << " = " << ClosingVoxels
                   << std::endl;
-        std::cout
-        << "Perhaps there is a mis-match between the voxel spacing and the assumption that  ClosingSize is given in mm"
-        << std::endl;
+        std::cout << "Perhaps there is a mis-match between the voxel spacing"
+                  << " and the assumption that  ClosingSize is given in mm"
+                  << std::endl;
         }
       dilateBallSize[d] = ClosingVoxels;
       erodeBallSize[d]  = ClosingVoxels;

--- a/BRAINSCommonLib/itkMultiModeHistogramThresholdBinaryImageFilter.hxx
+++ b/BRAINSCommonLib/itkMultiModeHistogramThresholdBinaryImageFilter.hxx
@@ -161,26 +161,22 @@ MultiModeHistogramThresholdBinaryImageFilter<TInputImage, TOutputImage>
       typedef MultiplyImageFilter<IntegerImageType, IntegerImageType> IntersectMasksFilterType;
       if( accumulate->GetLargestPossibleRegion().GetSize() != thresholdImage->GetLargestPossibleRegion().GetSize() )
         {
-        itkExceptionMacro(
-          << "Image data size mismatch " << accumulate->GetLargestPossibleRegion().GetSize() << " != "
+        itkExceptionMacro(<< "Image data size mismatch " << accumulate->GetLargestPossibleRegion().GetSize() << " != "
           << thresholdImage->GetLargestPossibleRegion().GetSize() << "." << std::endl );
         }
       if( accumulate->GetSpacing() != thresholdImage->GetSpacing() )
         {
-        itkExceptionMacro(
-          << "Image data spacing mismatch " << accumulate->GetSpacing() << " != " << thresholdImage->GetSpacing()
+        itkExceptionMacro(<< "Image data spacing mismatch " << accumulate->GetSpacing() << " != " << thresholdImage->GetSpacing()
           << "." << std::endl );
         }
       if( accumulate->GetDirection() != thresholdImage->GetDirection() )
         {
-        itkExceptionMacro(
-          << "Image data spacing mismatch " << accumulate->GetDirection() << " != " << thresholdImage->GetDirection()
+        itkExceptionMacro(<< "Image data spacing mismatch " << accumulate->GetDirection() << " != " << thresholdImage->GetDirection()
           << "." << std::endl );
         }
       if( accumulate->GetOrigin() != thresholdImage->GetOrigin() )
         {
-        itkExceptionMacro(
-          << "Image data spacing mismatch " << accumulate->GetOrigin() << " != " << thresholdImage->GetOrigin()
+        itkExceptionMacro(<< "Image data spacing mismatch " << accumulate->GetOrigin() << " != " << thresholdImage->GetOrigin()
           << "." << std::endl );
         }
       typename IntersectMasksFilterType::Pointer intersect = IntersectMasksFilterType::New();

--- a/BRAINSCommonLib/itkV3TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/BRAINSCommonLib/itkV3TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -237,9 +237,11 @@ ExtractSliceImageFilter< TInputImage, TOutputImage >
     case DIRECTIONCOLLAPSETOUNKOWN:
     default:
         {
-        itkExceptionMacro( << "It is required that the strategy for collapsing the direction matrix be explicitly specified. "
-          << "Set with either myfilter->SetDirectionCollapseToIdentity() or myfilter->SetDirectionCollapseToSubmatrix() "
-          << typeid( ImageBase< InputImageDimension > * ).name() );
+        itkExceptionMacro( << "It is required that the strategy for collapsing"
+                           " the direction matrix be explicitly specified. "
+                           "Set with either myfilter->SetDirectionCollapseToIdentity()"
+                           " or myfilter->SetDirectionCollapseToSubmatrix() "
+                           << typeid( ImageBase< InputImageDimension > * ).name() );
         }
       }
 

--- a/BRAINSConstellationDetector/TestSuite/CMakeLists.txt
+++ b/BRAINSConstellationDetector/TestSuite/CMakeLists.txt
@@ -7,7 +7,7 @@ set(DART_TESTING_TIMEOUT 15000)
 ## Test landmarksConstellationTrainingDefinitionIO
 ##
 add_executable(TestlandmarksConstellationTrainingDefinitionIO TestlandmarksConstellationTrainingDefinitionIO.cxx)
-target_link_libraries(TestlandmarksConstellationTrainingDefinitionIO ${ITK_LIBRARIES})
+target_link_libraries(TestlandmarksConstellationTrainingDefinitionIO BRAINSCommonLib ${ITK_LIBRARIES})
 
 set(ALL_TEST_PROGS
   BRAINSAlignMSP

--- a/BRAINSConstellationDetector/gui/QLabelList.cxx
+++ b/BRAINSConstellationDetector/gui/QLabelList.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "QLabelList.h"
+#include "DoubleToString.h"
 
 void QLabelList::createListItemSlot(const QString & label)
 {
@@ -357,6 +358,7 @@ void QLabelList::saveAsLandmarks()
 
 void QLabelList::writeLandmarks()
 {
+  DoubleToString doubleConvert;
   assert(m_outputLandmarks.compare("") != 0);
   assert(m_inputVolume.compare("") != 0);
 
@@ -396,8 +398,11 @@ void QLabelList::writeLandmarks()
       {
       if( ( it->first ).compare("") != 0 )
         {
-        myfile << it->first << "," << -( it->second )[0] << "," << -( it->second )[1] << "," << ( it->second )[2]
-               << ",1,1\n";
+        myfile << it->first << ","
+               << doubleConvert(-( it->second )[0]) << ","
+               << doubleConvert(-( it->second )[1]) << ","
+               << doubleConvert(( it->second )[2]) << ",1,1"
+               << std::endl;
         }
       }
 
@@ -428,7 +433,9 @@ void QLabelList::writeLandmarks()
     for( it = m_landmarks.begin(); it != m_landmarks.end(); ++it )
       {
       myfile << "id " << it->first << " labeltext " << it->first << " xyz "
-             << ( it->second )[0] << " " << ( it->second )[1] << " " << ( it->second )[2];
+             << doubleConvert(( it->second )[0]) << " "
+             << doubleConvert(( it->second )[1]) << " "
+             << doubleConvert((( it->second )[2]);
       if( ++index < m_landmarks.size() )
         {
         myfile << " orientationwxyz 0 0 0 1 selected 1 visibility 1\n";
@@ -439,22 +446,32 @@ void QLabelList::writeLandmarks()
         }
       }
 
-    myfile
-    <<
-    "<FiducialListStorage\n id=\"vtkMRMLFiducialListStorageNode1\" name=\"vtkMRMLFiducialListStorageNode1\" hideFromEditors=\"true\" selectable=\"true\" selected=\"false\" fileName=\""
-    << m_outputLandmarks
-    << "\" useCompression=\"1\" readState=\"0\" writeState=\"0\"></FiducialListStorage>\n";
-
-    myfile
-    <<
-    "<VolumeArchetypeStorage\n id=\"vtkMRMLVolumeArchetypeStorageNode1\" name=\"vtkMRMLVolumeArchetypeStorageNode1\" hideFromEditors=\"true\" selectable=\"true\" selected=\"false\" fileName=\""
-    << imageFullFilename
-    <<
-    "\" useCompression=\"1\" readState=\"0\" writeState=\"0\" centerImage=\"0\" singleFile=\"0\" UseOrientationFromFile=\"1\"></VolumeArchetypeStorage>\n";
-
-    myfile << "<Volume\n id=\"vtkMRMLScalarVolumeNode1\" name=\"" << imageFilenameWithoutPath
-           <<
-    "\" hideFromEditors=\"false\" selectable=\"true\" selected=\"false\" storageNodeRef=\"vtkMRMLVolumeArchetypeStorageNode1\" userTags=\"\" displayNodeRef=\"vtkMRMLScalarVolumeDisplayNode1\" ijkToRASDirections=\"-1   -0   0 -0   -0   1 0 1 0 \" spacing=\"1 1 1\" origin=\"-0 -255 -0\" labelMap=\"0\"></Volume>\n<VolumeDisplay\n id=\"vtkMRMLScalarVolumeDisplayNode1\" name=\"vtkMRMLScalarVolumeDisplayNode1\" hideFromEditors=\"true\" selectable=\"true\" selected=\"false\" color=\"0.5 0.5 0.5\" selectedColor=\"1 0 0\" selectedAmbient=\"0.4\" ambient=\"0\" diffuse=\"1\" selectedSpecular=\"0.5\" specular=\"0\" power=\"1\" opacity=\"1\" visibility=\"true\" clipping=\"false\" sliceIntersectionVisibility=\"false\" backfaceCulling=\"true\" scalarVisibility=\"false\" vectorVisibility=\"false\" tensorVisibility=\"false\" autoScalarRange=\"true\" scalarRange=\"0 100\" colorNodeRef=\"vtkMRMLColorTableNodeGrey\"  window=\"204\" level=\"153\" upperThreshold=\"32767\" lowerThreshold=\"-32768\" interpolate=\"1\" autoWindowLevel=\"1\" applyThreshold=\"0\" autoThreshold=\"0\"></VolumeDisplay>\n</MRML>\n";
+    myfile << "<FiducialListStorage\n id=\"vtkMRMLFiducialListStorageNode1\" "
+           << "name=\"vtkMRMLFiducialListStorageNode1\" hideFromEditors=\"true\" "
+           << "selectable=\"true\" selected=\"false\" fileName=\""
+           << m_outputLandmarks
+           << "\" useCompression=\"1\" readState=\"0\" writeState=\"0\"></FiducialListStorage>\n"
+           << "<VolumeArchetypeStorage\n id=\"vtkMRMLVolumeArchetypeStorageNode1\" "
+           << "name=\"vtkMRMLVolumeArchetypeStorageNode1\" hideFromEditors=\"true\""
+           << " selectable=\"true\" selected=\"false\" fileName=\""
+           << imageFullFilename
+           << "\" useCompression=\"1\" readState=\"0\" writeState=\"0\" "
+           << "centerImage=\"0\" singleFile=\"0\" UseOrientationFromFile=\"1\"></VolumeArchetypeStorage>\n"
+           << "<Volume\n id=\"vtkMRMLScalarVolumeNode1\" name=\"" << imageFilenameWithoutPath
+           << "\" hideFromEditors=\"false\" selectable=\"true\" selected=\"false\" "
+           << "storageNodeRef=\"vtkMRMLVolumeArchetypeStorageNode1\" userTags=\"\" "
+           << "displayNodeRef=\"vtkMRMLScalarVolumeDisplayNode1\" ijkToRASDirections=\"-1 "
+           << "  -0   0 -0   -0   1 0 1 0 \" spacing=\"1 1 1\" origin=\"-0 -255 -0\" "
+           << "labelMap=\"0\"></Volume>\n<VolumeDisplay\n id=\"vtkMRMLScalarVolumeDisplayNode1\" "
+           << "name=\"vtkMRMLScalarVolumeDisplayNode1\" hideFromEditors=\"true\" "
+           << "selectable=\"true\" selected=\"false\" color=\"0.5 0.5 0.5\" selectedColor=\"1 "
+           << "0 0\" selectedAmbient=\"0.4\" ambient=\"0\" diffuse=\"1\" selectedSpecular=\"0.5\" "
+           << "specular=\"0\" power=\"1\" opacity=\"1\" visibility=\"true\" clipping=\"false\" "
+           << "sliceIntersectionVisibility=\"false\" backfaceCulling=\"true\" scalarVisibility=\"false\" "
+           << "vectorVisibility=\"false\" tensorVisibility=\"false\" autoScalarRange=\"true\" "
+           << "scalarRange=\"0 100\" colorNodeRef=\"vtkMRMLColorTableNodeGrey\"  "
+           << "window=\"204\" level=\"153\" upperThreshold=\"32767\" lowerThreshold=\"-32768\" "
+           << "interpolate=\"1\" autoWindowLevel=\"1\" applyThreshold=\"0\" autoThreshold=\"0\"></VolumeDisplay>\n</MRML>\n";
 
     output.close();
     }

--- a/BRAINSConstellationDetector/landmarkStatistics/LmkStatistics.cxx
+++ b/BRAINSConstellationDetector/landmarkStatistics/LmkStatistics.cxx
@@ -41,8 +41,7 @@ int main( int argc, char * argv[] )
 
   if(argc < 2)
     {
-    std::cerr << "Usage : " << argv[0]
-              << " <#of landmark pairs> <lmk-pair1> <lmk-pair2> ... <lmk-pairN>"
+    std::cerr << "Usage : " << argv[0] << " <#of landmark pairs> <lmk-pair1> <lmk-pair2> ... <lmk-pairN>"
               << std::endl;
     return EXIT_FAILURE;
     }

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetector.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetector.cxx
@@ -131,9 +131,8 @@ int main( int argc, char *argv[] )
     }
     catch( itk::ExceptionObject & err )
     {
-      std::cerr << "Exception Object caught:\n"
-                << err << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << "Exception Object caught:\n" << err << std::endl;
+    return EXIT_FAILURE;
     }
 
   return 0;

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetector2.hxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetector2.hxx
@@ -216,7 +216,7 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
     {
     image = volOrig;
     }
-      
+
   landmarksConstellationDetector myDetector;
     {
     // a little abuse of the duplicator here
@@ -225,13 +225,13 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
     duplicator->Update();
     // The detector will use the output image after the Hough eye detector
     myDetector.SetVolOrig( duplicator->GetOutput() );
-        
+
     // The detector also needs the original input if it has to fix a bad estimation of the MSP
     duplicator->SetInputImage( image );
     duplicator->Update();
     myDetector.SetOriginalInput( duplicator->GetOutput() );
     }
-    
+
   myDetector.SetInputTemplateModel( myModel );
   myDetector.SetLlsMatrices( this->m_LlsMatrices );
   myDetector.SetLlsMeans( this->m_LlsMeans );
@@ -385,7 +385,7 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
 
       {
         image = myDetector.GetOriginalInput(); // image -> myDetector(modification May happen) -> image
-          
+
         {
         //const SImageType * constImage( this->m_OriginalInputImage.GetPointer() );
         const SImageType * constImage( image.GetPointer() );
@@ -399,8 +399,8 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
         }
 
         {
-        this->m_OutputResampledImage = TransformResample<SImageType, SImageType> ( image, 
-                                                                                   MakeIsoTropicReferenceImage(), 
+        this->m_OutputResampledImage = TransformResample<SImageType, SImageType> ( image,
+                                                                                   MakeIsoTropicReferenceImage(),
                                                                                    BackgroundFillValue,
                                                                                    GetInterpolatorFromString<SImageType>(this->m_InterpolationMode),
                                                                                    this->m_VersorTransform.GetPointer() );
@@ -507,14 +507,14 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
             {
                 std::cout << lit->first << "=" << lit->second[0] << "," << lit->second[1] << "," << lit->second[2] << std::endl << std::endl;
             }
-                  
+
             std::cout << "filename : " << this->m_WriteBranded2DImage << std::endl;
-            
+
             itkUtil::WriteImage<SImageType>(this->m_OutputResampledImage, "m_OutputResampledImage.nii.gz");
-            
+
             double height = myDetector.GetModelHeight("AC");
             */
-            
+
             MakeBranded2DImage(this->m_OutputResampledImage.GetPointer(), myDetector,
                            this->m_AlignedPoints["RP"],
                            this->m_AlignedPoints["AC"],
@@ -534,8 +534,6 @@ BRAINSConstellationDetector2<TInputImage, TOutputImage>
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
-
-  // os << "Mode: " << this->m_Mode << std::endl;
 }
 
 }

--- a/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
+++ b/BRAINSConstellationDetector/src/BRAINSConstellationDetectorPrimary.cxx
@@ -99,7 +99,7 @@ bool BRAINSConstellationDetectorPrimary::Compute( void )
     catch( itk::ExceptionObject & err )
     {
         std::cerr << " Error while reading image file( s ) with ITK:\n "
-        << err << std::endl;
+                  << err << std::endl;
     }
     std::cout << "Processing: " << this->m_inputVolume << std::endl;
     
@@ -332,7 +332,7 @@ bool BRAINSConstellationDetectorPrimary::Compute( void )
              ( this->m_inputLandmarksPaired.compare( "" ) != 0 ) ) )
     {
         std::cerr << "The outputLandmark parameter should be paired with"
-        << "the inputLandmark parameter." << std::endl;
+                  << "the inputLandmark parameter." << std::endl;
         std::cerr << "No output acpc-aligned landmark list file is generated" << std::endl;
     }
     //------------------------

--- a/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
+++ b/BRAINSConstellationDetector/src/BinaryMaskEditorBasedOnLandmarks.cxx
@@ -7,42 +7,43 @@
 #include "itkImageRegionIterator.h"
 #include "itkImageFileWriter.h"
 #include "vcl_algorithm.h"
-
 #include "BinaryMaskEditorBasedOnLandmarksCLP.h"
+#include "DoubleToString.h"
 
 class ThreeLandmarksForPlane
 {
   // The definition depends on Slicer3LandmarkIO.
-  // Point type is simply itk::Pointe<double, 3> 
+  // Point type is simply itk::Pointe<double, 3>
   public:
   PointType A;
   PointType B;
   PointType C;
 
-  
+
   typedef itk::Point<double, 3>    VectorType;
 
   void SetNormal()
   {
+  DoubleToString doubleConvert;
   // Determine AB and AC vector components
   VectorType AB;
   AB[ 0 ] = B[ 0 ] - A[ 0 ];
   AB[ 1 ] = B[ 1 ] - A[ 1 ];
   AB[ 2 ] = B[ 2 ] - A[ 2 ];
-  std::cout<<"AB::: [" 
-           << AB[0] << ", "
-           << AB[1] << ", "
-           << AB[2] << " ]"
+  std::cout<<"AB::: ["
+           << doubleConvert(AB[0]) << ", "
+           << doubleConvert(AB[1]) << ", "
+           << doubleConvert(AB[2]) << " ]"
            <<std::endl;
-  
+
   VectorType AC;
   AC[ 0 ] = C[ 0 ] - A[ 0 ];
-  AC[ 1 ] = C[ 1 ] - A[ 1 ]; 
+  AC[ 1 ] = C[ 1 ] - A[ 1 ];
   AC[ 2 ] = C[ 2 ] - A[ 2 ];
-  std::cout<<"AC::: [" 
-           << AC[0] << ", "
-           << AC[1] << ", "
-           << AC[2] << " ]"
+  std::cout<<"AC::: ["
+           << doubleConvert(AC[0]) << ", "
+           << doubleConvert(AC[1]) << ", "
+           << doubleConvert(AC[2]) << " ]"
            <<std::endl;
 
   // Find cross product components
@@ -54,11 +55,11 @@ class ThreeLandmarksForPlane
   double magnitude = vcl_sqrt( normal[0] * normal[0] +
                                normal[1] * normal[1] +
                                normal[2] * normal[2] );
-    
-  std::cout<<"Normal::: Before Norm[" 
-           << normal[0] << ", "
-           << normal[1] << ", "
-           << normal[2] << " ]"
+
+  std::cout<<"Normal::: Before Norm["
+           << doubleConvert(normal[0]) << ", "
+           << doubleConvert(normal[1]) << ", "
+           << doubleConvert(normal[2]) << " ]"
            <<std::endl;
   normal[ 0 ] = normal[ 0 ] / magnitude;
   normal[ 1 ] = normal[ 1 ] / magnitude;
@@ -70,14 +71,14 @@ class ThreeLandmarksForPlane
     normal[ 1 ] = - normal[ 1 ] ;
     normal[ 2 ] = - normal[ 2 ] ;
     }
-  std::cout<<"Normal:::  After Norm[" 
-           << normal[0] << ", "
-           << normal[1] << ", "
-           << normal[2] << " ]"
+  std::cout<<"Normal:::  After Norm["
+           << doubleConvert(normal[0]) << ", "
+           << doubleConvert(normal[1]) << ", "
+           << doubleConvert(normal[2]) << " ]"
            <<std::endl;
   }
 
-  double 
+  double
   GetRelativeLocationToPlane( PointType x )
   {
     double answer =
@@ -94,18 +95,19 @@ class ThreeLandmarksForPlane
 
   private:
   VectorType normal;
-  
+
 };
 
-// ------------------------------------------------------------------------ // 
+
+// ------------------------------------------------------------------------ //
 template<class TImageType>
 void
 CutBinaryVolumeByPlaneWithDirection( typename TImageType::Pointer * _imageVolume,
-                                     ThreeLandmarksForPlane * currentPlane, 
+                                     ThreeLandmarksForPlane * currentPlane,
                                      const std::string & direction )
 {
   typedef itk::ImageRegionIterator< TImageType > ImageRegionIteratorType;
-  ImageRegionIteratorType it(  *_imageVolume, 
+  ImageRegionIteratorType it(  *_imageVolume,
                               (*_imageVolume)->GetRequestedRegion() );
   std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
 
@@ -114,24 +116,24 @@ CutBinaryVolumeByPlaneWithDirection( typename TImageType::Pointer * _imageVolume
     PointType currentPhysicalLocation;
     (*_imageVolume)->TransformIndexToPhysicalPoint( it.GetIndex(), currentPhysicalLocation );
 
-    if( direction == "true" && 
+    if( direction == "true" &&
         (*currentPlane).GetRelativeLocationToPlane( currentPhysicalLocation ) > 0.0F )
-      { 
-      it.Set( 0.0F ); 
+      {
+      it.Set( 0.0F );
       }
     else if( direction =="false" &&
         (*currentPlane).GetRelativeLocationToPlane( currentPhysicalLocation ) < 0.0F ){ it.Set( 0.0F ); }
     }
 
 }
-// ------------------------------------------------------------------------ // 
+// ------------------------------------------------------------------------ //
 template <class TImageType>
 void
-CutBinaryVolumeByPointWithDirection( typename TImageType::Pointer * _imageVolume, 
+CutBinaryVolumeByPointWithDirection( typename TImageType::Pointer * _imageVolume,
                                      const PointType _landmark,
                                      const std::string & _direction )
 {
-  
+
   // set directional constant for convenient programming
   //
   enum DIRECTION{
@@ -145,7 +147,7 @@ CutBinaryVolumeByPointWithDirection( typename TImageType::Pointer * _imageVolume
   else if( _direction == "INFERIOR" ) { myDirection = INFERIOR; }
 
   typedef itk::ImageRegionIterator< TImageType > ImageRegionIteratorType;
-  ImageRegionIteratorType it(  *_imageVolume, 
+  ImageRegionIteratorType it(  *_imageVolume,
                               (*_imageVolume)->GetRequestedRegion() );
   std::cout<<__LINE__<<"::"<<__FILE__<<std::endl;
 
@@ -181,7 +183,7 @@ int main( int argc, char * argv[] )
 {
   PARSE_ARGS;
 
-  // check input 
+  // check input
   //
   if( inputBinaryVolume.empty() ||
       inputLandmarksFilename.empty()
@@ -197,7 +199,7 @@ int main( int argc, char * argv[] )
     {
     std::cout<<" Size should match between inputLandmarkNames and"
              <<" setCutDirectionForLandmark but "
-             << inputLandmarkNames.size() << " != " 
+             << inputLandmarkNames.size() << " != "
              << setCutDirectionForLandmark.size() <<std::endl;
     }
 
@@ -218,7 +220,7 @@ int main( int argc, char * argv[] )
 
   // read landmark file in
   //
-  std::cout << "Reading: " 
+  std::cout << "Reading: "
             << inputLandmarksFilename << std::endl;
   LandmarksMapType landmarksSet = ReadSlicer3toITKLmk( inputLandmarksFilename );
 
@@ -242,7 +244,7 @@ int main( int argc, char * argv[] )
     {
     if( landmarksSet.find( *ldmkIt ) == landmarksSet.end() )
       {
-      std::cerr << "ERROR: Landmark not found: " << *ldmkIt << std::endl; 
+      std::cerr << "ERROR: Landmark not found: " << *ldmkIt << std::endl;
       std::exit( EXIT_FAILURE );
       }
 
@@ -273,7 +275,7 @@ int main( int argc, char * argv[] )
 
   if( inputLandmarkNamesForObliquePlane.size() % 3 != 0)
     {
-    std::cerr << "ERROR: Landmarks set for plane has to given as a multiple of three: " 
+    std::cerr << "ERROR: Landmarks set for plane has to given as a multiple of three: "
               << inputLandmarkNamesForObliquePlane.size() << std::endl;
     std::exit( EXIT_FAILURE );
     }
@@ -286,13 +288,13 @@ int main( int argc, char * argv[] )
       {
       std::cout<<"Directional information for plane has to be match "
                <<"to the number of plane descriptions.("
-               <<inputLandmarkNamesForObliquePlane.size() <<"!=" 
+               <<inputLandmarkNamesForObliquePlane.size() <<"!="
                <<setCutDirectionForObliquePlane.size()<< ")"
                <<std::endl;
       return( EXIT_FAILURE );
       }
   }
-                
+
   for( LandMarkForPlaneType::const_iterator  inputLdmrIt= inputLandmarkNamesForObliquePlane.begin();
        inputLdmrIt< inputLandmarkNamesForObliquePlane.end();
        ++inputLdmrIt )

--- a/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
+++ b/BRAINSConstellationDetector/src/fcsv_to_hdf5.cxx
@@ -37,6 +37,7 @@ benefits more from readability than speed.
 
 #include "itkPoint.h"
 #include "fcsv_to_hdf5CLP.h"
+#include "DoubleToString.h"
 
 #include "LLSModel.h"
 #include "BRAINSThreadControl.h"
@@ -829,15 +830,16 @@ This information is now completely contained in the byClassLandmarkMatrix object
   // txt version
   std::ofstream fid;
   fid.open("LME_EPCA.txt");
+  DoubleToString doubleToString;
   for( unsigned int i = 0; i < numNewLandmarks; i++ )
     {
     fid << byClassLandmarkMatrix["newLandmarks"][i].first << std::endl;
     for( unsigned int d = 0; d < dim; d++ )
       {
-      fid << s(d, i) << " ";
+      fid << doubleToString(s(d, i)) << " ";
       }
     fid << std::endl;
-    fid << search_radius(i, 0) << std::endl;
+    fid << doubleToString(search_radius(i, 0)) << std::endl;
     fid << M[i].rows() << std::endl;
     unsigned int l = 0;
     while( l < dim )
@@ -845,7 +847,7 @@ This information is now completely contained in the byClassLandmarkMatrix object
       vnl_vector<double> temp = M[i].get_column(l);
       for( unsigned int ll = 0; ll < M[i].rows(); ll++ )
         {
-        fid << temp[ll] << " ";
+        fid << doubleToString(temp[ll]) << " ";
         }
       fid << std::endl;
       l++;
@@ -860,7 +862,7 @@ This information is now completely contained in the byClassLandmarkMatrix object
   for( unsigned int i = 0; i < numNewLandmarks; i++ )
     {
     fid << byClassLandmarkMatrix["newLandmarks"][i].first << std::endl;
-    fid << search_radius(i, 0) << std::endl;
+    fid << doubleToString(search_radius(i, 0)) << std::endl;
     }
   fid.close();
 
@@ -881,7 +883,7 @@ This information is now completely contained in the byClassLandmarkMatrix object
       }
     for( unsigned int d = 0; d < dim; d++ )
       {
-      fid << s(d, i) << " ";
+      fid << doubleToString(s(d, i)) << " ";
       }
     fid << "];" << std::endl;
 
@@ -900,7 +902,7 @@ This information is now completely contained in the byClassLandmarkMatrix object
       vnl_vector<double> temp = M[i].get_column(l);
       for( unsigned int ll = 0; ll < M[i].rows(); ll++ )
         {
-        fid << temp[ll] << " ";
+        fid << doubleToString(temp[ll]) << " ";
         }
       fid << ";" << std::endl;
       l++;

--- a/BRAINSConstellationDetector/src/itkLabelOverlayImageFilter.hxx
+++ b/BRAINSConstellationDetector/src/itkLabelOverlayImageFilter.hxx
@@ -117,8 +117,7 @@ LabelOverlayImageFilter<TInputImage, TLabelImage, TOutputImage>
      << static_cast<typename NumericTraits<double>::PrintType>( m_Opacity )
      << std::endl
      << indent << "BackgroundValue: "
-     << static_cast<
-    typename NumericTraits<LabelPixelType>::PrintType>( m_BackgroundValue )
+     << static_cast<typename NumericTraits<LabelPixelType>::PrintType>( m_BackgroundValue )
      << std::endl;
 }
 

--- a/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
+++ b/BRAINSConstellationDetector/src/itkReflectiveCorrelationCenterToImageMetric.h
@@ -31,6 +31,7 @@
 #include "landmarksConstellationCommon.h"
 #include "GenericTransformImage.h"
 #include "itkStatisticsImageFilter.h"
+#include "DoubleToString.h"
 
 // Optimize the A,B,C vector
 class Rigid3DCenterReflectorFunctor : public vnl_cost_function
@@ -89,11 +90,12 @@ public:
     // DEBUGGING INFORMATION
     if( LMC::globalverboseFlag == true )
       {
+      DoubleToString doubleToString;
       std::cout << "quick search 15 deg "
-                << " HA= " << this->m_params[0] * 180.0 / vnl_math::pi
-                << " BA= " << this->m_params[1] * 180.0 / vnl_math::pi
-                << " XO= " << this->m_params[2]
-                << " cc="  <<  this->f(this->m_params)
+                << " HA= " << doubleToString(this->m_params[0] * 180.0 / vnl_math::pi)
+                << " BA= " << doubleToString(this->m_params[1] * 180.0 / vnl_math::pi)
+                << " XO= " << doubleToString(this->m_params[2])
+                << " cc="  <<  doubleToString(this->f(this->m_params))
                 << " iterations=" << this->GetIterations()
                 << std::endl;
       }
@@ -414,10 +416,13 @@ public:
 */
   void Update(void)
   {
+    DoubleToString doubleToString;
     this->m_Optimizer.minimize(this->m_params);
     m_cc = this->f(this->m_params);
-    std::cout << this->m_params[0] * 180.0 / vnl_math::pi << " " << this->m_params[1] * 180.0 / vnl_math::pi << " "
-              << this->m_params[2] << " cc= " << m_cc << " iters= " << this->GetIterations()
+    std::cout << doubleToString(this->m_params[0] * 180.0 / vnl_math::pi) << " "
+              << doubleToString(this->m_params[1] * 180.0 / vnl_math::pi) << " "
+              << this->m_params[2] << " cc= "
+              << doubleToString(m_cc) << " iters= " << this->GetIterations()
               << std::endl;
   }
 

--- a/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationModelIO.h
@@ -13,7 +13,7 @@
 
 #include "itkByteSwapper.h"
 #include "itkIO.h"
-
+#include "DoubleToString.h"
 #include <vector>
 #include <fstream>
 #include <iostream>
@@ -232,7 +232,7 @@ public:
     //
     //
     // //////////////////////////////////////////////////////////////////////////
-
+    DoubleToString doubleToString;
     std::ofstream output( filename.c_str() ); // open setup file for reading
 
     if( !output.is_open() )
@@ -259,8 +259,8 @@ public:
            it2 != this->m_TemplateMeansComputed.end(); ++it2 )
         {
         output << it2->first.c_str() << std::endl;
-        output << this->GetRadius(it2->first) << std::endl;
-        output << this->GetHeight(it2->first) << std::endl;
+        output << doubleToString(this->GetRadius(it2->first)) << std::endl;
+        output << doubleToString(this->GetHeight(it2->first)) << std::endl;
         }
       output << "END" << std::endl;
 
@@ -611,6 +611,7 @@ public:
           const Float2DVectorType & a,
           const Float2DVectorType & b)
   {
+    DoubleToString doubleToString;
     for( unsigned i = 0; i < a.size(); i++ )
       {
       for( unsigned j = 0; j < a[i].size(); j++ )
@@ -618,9 +619,9 @@ public:
         if( NE(a[i][j], b[i][j]) )
           {
           std::cerr << label << " a[" << i
-                    << "] = " << a[i][j]
+                    << "] = " << doubleToString(a[i][j])
                     << "b[" << j << "] = "
-                    << b[i][j] << std::endl;
+                    << doubleToString(b[i][j]) << std::endl;
           return true;
           }
         }

--- a/BRAINSConstellationDetector/src/landmarksConstellationTrainingDefinitionIO.h
+++ b/BRAINSConstellationDetector/src/landmarksConstellationTrainingDefinitionIO.h
@@ -14,7 +14,7 @@
 #include <itkContinuousIndex.h>
 #include "landmarksDataSet.h"
 #include "landmarksConstellationModelBase.h"
-
+#include "DoubleTostring.h"
 // HACK:  Remove the multiple inheritance here.
 class landmarksConstellationTrainingDefinitionIO : public landmarksConstellationModelBase,
   public std::vector<landmarksDataSet>   // This should be a private member
@@ -133,20 +133,21 @@ private:
 inline
 std::ostream & operator<<(std::ostream & os, const landmarksConstellationTrainingDefinitionIO & def)
 {
+  DoubleToString doubleToString;
   os << def.GetNumDataSets() << std::endl;
   os << def.GetSearchboxDims() << " "
   << def.GetResolutionUnits() << std::endl;
-  os << def.GetRadius("RP") << " "
-  << def.GetHeight("RP") << std::endl;
-  os << def.GetRadius("AC") << " "
-  << def.GetHeight("AC") << std::endl;
-  os << def.GetRadius("PC") << " "
-  << def.GetHeight("PC") << std::endl;
-  os << def.GetRadius("VN4") << " "
-  << def.GetHeight("VN4") << std::endl;
-  os << def.GetInitialRotationAngle() << " "
-  << def.GetInitialRotationStep() << " "
-  << def.GetNumRotationSteps() << std::endl << std::endl;
+  os << doubleToString(def.GetRadius("RP")) << " "
+     << doubleToString(def.GetHeight("RP")) << std::endl;
+  os << doubleToString(def.GetRadius("AC")) << " "
+     << doubleToString(def.GetHeight("AC")) << std::endl;
+  os << doubleToString(def.GetRadius("PC")) << " "
+     << doubleToString(def.GetHeight("PC")) << std::endl;
+  os << doubleToString(def.GetRadius("VN4")) << " "
+     << doubleToString(def.GetHeight("VN4")) << std::endl;
+  os << doubleToString(def.GetInitialRotationAngle()) << " "
+     << def.GetInitialRotationStep() << " "
+     << def.GetNumRotationSteps() << std::endl << std::endl;
   for( unsigned int i = 0; i < def.GetNumDataSets(); i++ )
     {
     os << def[i] << std::endl;

--- a/BRAINSConstellationDetector/src/tempSphereFromAreaEstimates.cxx
+++ b/BRAINSConstellationDetector/src/tempSphereFromAreaEstimates.cxx
@@ -36,6 +36,7 @@
 #include <itkMinimumMaximumImageCalculator.h>
 #include <itkHistogram.h>
 #include <vnl/vnl_math.h>
+#include "DoubleToString.h"
 
 double FindCenterOfBrainBasedOnTopOfHead(SImageType::Pointer & foreground,  SImageType::Pointer & volOrig,
                                          bool maximize, unsigned int axis,

--- a/BRAINSCut/BRAINSCutApplyModel.cxx
+++ b/BRAINSCut/BRAINSCutApplyModel.cxx
@@ -13,6 +13,7 @@
 #include <itkLabelStatisticsImageFilter.h>
 #include <itkBinaryFillholeImageFilter.h>
 #include <itkMultiplyImageFilter.h>
+#include "DoubleToString.h"
 
 
 // TODO: consider using itk::LabelMap Hole filling process in ITK4
@@ -140,6 +141,7 @@ void
 BRAINSCutApplyModel
 ::ApplyOnSubject( DataSet& subject)
 {
+  DoubleToString doubleToString;
   const std::string subjectID(subject.GetAttribute<StringValue>("Name") );
 
   std::map<std::string, WorkingImagePointer> deformedSpatialLocationImageList;
@@ -288,10 +290,10 @@ BRAINSCutApplyModel
           const float       SSE = ComputeSSE( predictedOutputVector, roiReferenceFilename );
 
           m_ANNTestingSSEFileStream << currentROIName
-                                  << ", subjectID, " << subjectID
-                                  << ", Iteration, " << currentIteration
-                                  << ", SSE, " << SSE
-                                  << std::endl;
+                                    << ", subjectID, " << subjectID
+                                    << ", Iteration, " << currentIteration
+                                    << ", SSE, " << doubleToString(SSE)
+                                    << std::endl;
           }
         }
       predictedOutputVector.clear();

--- a/BRAINSCut/BRAINSFeatureCreators/ImageRegionPlotter/CMakeLists.txt
+++ b/BRAINSCut/BRAINSFeatureCreators/ImageRegionPlotter/CMakeLists.txt
@@ -6,5 +6,5 @@ set(ALL_PROGS_LIST
   ImageRegionPlotter
   )
 foreach( prog ${ALL_PROGS_LIST} )
-  StandardBRAINSBuildMacro( NAME ${prog} TARGET_LIBRARIES ${ITK_LIBRARIES} )
+  StandardBRAINSBuildMacro( NAME ${prog} TARGET_LIBRARIES BRAINSCommonLib ${ITK_LIBRARIES} )
 endforeach()

--- a/BRAINSCut/BRAINSFeatureCreators/ImageRegionPlotter/ImageRegionPlotter.cxx
+++ b/BRAINSCut/BRAINSFeatureCreators/ImageRegionPlotter/ImageRegionPlotter.cxx
@@ -16,6 +16,7 @@
 #include "itkBRAINSROIAutoImageFilter.h"
 
 #include "itkLabelStatisticsImageFilter.h"
+#include "DoubleToString.h"
 #include <map>
 
 #include <fstream>
@@ -71,6 +72,7 @@ MapHistogramToImage( typename TImageType::Pointer inputImage,
                      bool verbose)
 {
 
+  DoubleToString doubleToString;
   /* ------------------------------------------------------------------------
    * Make Look Up Table
      ------------------------------------------------------------------------ */
@@ -131,11 +133,12 @@ MapHistogramToImage( typename TImageType::Pointer inputImage,
 
     if( verbose )
       {
-      std::cout << intensity << " <--> "
-                << quantile << std::endl;
+      std::cout << doubleToString(intensity) << " <--> "
+                << doubleToString(quantile) << std::endl;
       }
 
-    mapOutFileStream << intensity << "," << quantile
+    mapOutFileStream << doubleToString(intensity)
+                     << "," << doubleToString(quantile)
                      << std::endl;
     }
   mapOutFileStream.close();
@@ -199,6 +202,7 @@ main(int argc, char *argv[])
   typedef double PixelType;
   const int Dimension = 3;
   typedef itk::Image<PixelType, Dimension> ImageType;
+
 
   // there has to be two input volumes and label volume
   if( (!inputLabelVolume.empty() ) && ( !inputVolume1.empty() ) &&

--- a/BRAINSCut/TrainModel.cxx
+++ b/BRAINSCut/TrainModel.cxx
@@ -220,9 +220,8 @@ void ANNTrain( // NetConfiguration & prob,
   if( ( InputVectorSize == 0 ) || ( NumberTrainingVectorsFromFile == 0 )
       || ( OutputVectorSize == 0 ) )
     {
-    std::cout
-    << "Input/output vector size and vector count must be non-zero."
-    << std::endl;
+    std::cout << "Input/output vector size and vector count must be non-zero."
+              << std::endl;
     return;
     }
   // set up shuffled ordering to read out of training vector file

--- a/BRAINSSurfaceTools/BRAINSSurfaceCommon/itkQuadEdgeMeshVectorDataVTKPolyDataWriter.hxx
+++ b/BRAINSSurfaceTools/BRAINSSurfaceCommon/itkQuadEdgeMeshVectorDataVTKPolyDataWriter.hxx
@@ -20,34 +20,34 @@
 
 #include "itkQuadEdgeMeshVectorDataVTKPolyDataWriter.h"
 #include "itkMeasurementVectorTraits.h"
-
+#include "DoubleToString.h"
 
 namespace itk
 {
 
-// 
+//
 // Constructor
-// 
+//
 template< class TMesh >
-QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh> 
-::QuadEdgeMeshVectorDataVTKPolyDataWriter() 
+QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
+::QuadEdgeMeshVectorDataVTKPolyDataWriter()
 {
   m_CellDataName = "";
   m_PointDataName = "";
 }
 
-// 
+//
 // Destructor
-// 
+//
 template< class TMesh >
-QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh> 
+QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 ::~QuadEdgeMeshVectorDataVTKPolyDataWriter()
 {
 }
 
 template< class TMesh >
 void
-QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh> 
+QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 ::GenerateData()
 {
   this->Superclass::GenerateData();
@@ -57,11 +57,11 @@ QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 
 template< class TMesh >
 void
-QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh> 
+QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 ::WriteCellData()
 {
   CellDataContainerConstPointer celldata = this->m_Input->GetCellData();
-
+  DoubleToString doubleToString;
   if( celldata )
     {
     if( celldata->Size() != 0 )
@@ -79,7 +79,7 @@ QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
         {
         outputFile <<"double double" <<std::endl;
         }
-      
+
       outputFile <<"LOOKUP_TABLE default" <<std::endl;
 
       unsigned long k(0);
@@ -94,7 +94,7 @@ QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
         CellType* cellPointer = it.Value();
         if( cellPointer->GetType() != 1 )
           {
-          outputFile <<c_it.Value();
+          outputFile << doubleToString(c_it.Value());
           if( k++ % 3 == 0 )
             {
             outputFile <<std::endl;
@@ -111,11 +111,11 @@ QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 
 template< class TMesh >
 void
-QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh> 
+QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
 ::WritePointData()
 {
   PointDataContainerConstPointer pointdata = this->m_Input->GetPointData();
-
+  DoubleToString doubleToString;
   if( pointdata )
     {
     std::ofstream outputFile( this->m_FileName.c_str(), std::ios_base::app );
@@ -142,7 +142,7 @@ QuadEdgeMeshVectorDataVTKPolyDataWriter<TMesh>
       {
       for( unsigned int j = 0; j < vectorSize; j++ )
         {
-        outputFile << static_cast< double >( c_it.Value()[j] ) << " ";
+        outputFile << doubleToString(static_cast< double >( c_it.Value()[j] )) << " ";
         ++k;
         if( k % 3 == 0 )
           {

--- a/BRAINSSurfaceTools/BRAINSSurfaceGeneration/BRAINSMeasureSurface.cxx
+++ b/BRAINSSurfaceTools/BRAINSSurfaceGeneration/BRAINSMeasureSurface.cxx
@@ -36,7 +36,7 @@
 #include <sys/stat.h>
 #include <ctime>
 #include <algorithm>
-
+#include "DoubleToString.h"
 template <class T>
 const T & min ( const T & a, const T & b )
 {
@@ -62,7 +62,7 @@ int main( int argc, char **argv )
     std::cout << "\t\t" << i << ": " << labels[i] << std::endl;
     }
   std::cout << "------------------------------------------------------" << std::endl;
-
+  DoubleToString doubleToString;
   // Read Surface
   vtkPolyData *surfaceData = vtkPolyData::New();
 
@@ -264,17 +264,17 @@ int main( int argc, char **argv )
                 << ", " << labels[i - 1];
         }
 
-      csvfile << ", " << surfaceArea->GetValue(i);
-      csvfile << ", " << corticalThickness->GetValue(i);
-      csvfile << ", " << corticalCurvature->GetValue(i);
+      csvfile << ", " << doubleToString(surfaceArea->GetValue(i));
+      csvfile << ", " << doubleToString(corticalThickness->GetValue(i));
+      csvfile << ", " << doubleToString(corticalCurvature->GetValue(i));
 
-      csvfile << ", " << gyralArea->GetValue(i);
-      csvfile << ", " << gyralThickness->GetValue(i);
-      csvfile << ", " << gyralCurvature->GetValue(i);
+      csvfile << ", " << doubleToString(gyralArea->GetValue(i));
+      csvfile << ", " << doubleToString(gyralThickness->GetValue(i));
+      csvfile << ", " << doubleToString(gyralCurvature->GetValue(i));
 
-      csvfile << ", " << sulcalArea->GetValue(i);
-      csvfile << ", " << sulcalThickness->GetValue(i);
-      csvfile << ", " << sulcalCurvature->GetValue(i) << std::endl;
+      csvfile << ", " << doubleToString(sulcalArea->GetValue(i));
+      csvfile << ", " << doubleToString(sulcalThickness->GetValue(i));
+      csvfile << ", " << doubleToString(sulcalCurvature->GetValue(i) << std::endl);
       }
 
     csvfile.close();

--- a/DWIConvert/CMakeLists.txt
+++ b/DWIConvert/CMakeLists.txt
@@ -19,8 +19,7 @@ foreach(f ${DWIConvertSupportLib_SRCS})
 endforeach()
 
 add_library(DWIConvertSupportLib STATIC ${DWIConvertSupportLib_SRCS})
-target_link_libraries(DWIConvertSupportLib ${ITK_LIBRARIES}
-  ${double-conversion_LIBRARIES} )
+target_link_libraries(DWIConvertSupportLib ${ITK_LIBRARIES} )
 
 set(MODULE_NAME DWIConvert)
 #-----------------------------------------------------------------------------
@@ -32,7 +31,7 @@ set(MODULE_NAME DWIConvert)
 
 # several files needed down in ExtenededTesting
 StandardBRAINSBuildMacro(NAME DWIConvert
-  TARGET_LIBRARIES DWIConvertSupportLib)
+  TARGET_LIBRARIES BRAINSCommonLib DWIConvertSupportLib)
 
 if(BUILD_TESTING AND NOT Slicer_BUILD_BRAINSTOOLS)
   add_subdirectory(TestSuite)

--- a/DWIConvert/TestSuite/CMakeLists.txt
+++ b/DWIConvert/TestSuite/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(NrrdToNIfTI DWIConvertSupportLib)
 set (CLP DWIConvert)
 add_executable(${CLP}Test ${CLP}Test.cxx ${DWIConvertTest_SRC})
 add_dependencies(${CLP}Test ${CLP})
-target_link_libraries(${CLP}Test DWIConvertSupportLib )
+target_link_libraries(${CLP}Test DWIConvertSupportLib BRAINSCommonLib )
 
 if(NOT SETIFEMPTY)
   macro(SETIFEMPTY)

--- a/GTRACT/Cmdline/CMakeLists.txt
+++ b/GTRACT/Cmdline/CMakeLists.txt
@@ -34,7 +34,7 @@ set(ALL_PROGS_LIST
 #  gtractGraphSearchTracking
   )
 foreach(prog ${ALL_PROGS_LIST})
-  StandardBRAINSBuildMacro(NAME ${prog} TARGET_LIBRARIES GTRACTCommon ${double-conversion_LIBRARIES} )
+  StandardBRAINSBuildMacro(NAME ${prog} TARGET_LIBRARIES GTRACTCommon BRAINSCommonLib)
 endforeach()
 
 


### PR DESCRIPTION
There are actually not that many places where IOStream I/O outputs double precision data where it actually matters.  I fixed every place that seemed important.

I did not fix:
1. PrintSelf functions -- only used for debugging
2. Logging messages
3. Exception messages
4. Output to std::cout and std::cerr
