### PR TITLE
Add dwi padding

### DIFF
--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
@@ -45,11 +45,11 @@
     <label>Main Parameters</label>
 
     <integer-vector>
-      <name>paddedImageSize</name>
-      <longflag>paddedImageSize</longflag>
-      <label>Padded Image Size</label>
-      <description>Final image size of each diffusion weighted volume in the output image after image padding.</description>
-      <default>0,0,0</default>
+      <name>imagePadding</name>
+      <longflag>imagePadding</longflag>
+      <label>Image Padding</label>
+      <description>Number of voxels to be added to the lower x, y, z region and uppser x, y, z region.</description>
+      <default>0,0,0,0,0,0</default>
     </integer-vector>
   
   </parameters>

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
@@ -61,7 +61,7 @@
     <image type="diffusion-weighted">
       <name>outputVolume</name>
       <longflag>outputVolume</longflag>
-      <description>Required: output image (NRRD file) that has been transformed into the space of the structural image.</description>
+      <description>Required: output image (NRRD file) that has been rigidly transformed into the space of the structural image and padded if image padding was changed from 0,0,0 default.</description>
       <label>Output File</label>
       <channel>output</channel>
     </image>

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
@@ -48,8 +48,8 @@
       <name>imagePadding</name>
       <longflag>imagePadding</longflag>
       <label>Image Padding</label>
-      <description>Number of voxels to be added to the lower x, y, z region and uppser x, y, z region.</description>
-      <default>0,0,0,0,0,0</default>
+      <description>Number of voxels to be added to the lower x, y, z region and upper x, y, z region.</description>
+      <default>0,0,0</default>
     </integer-vector>
   
   </parameters>

--- a/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
+++ b/GTRACT/Cmdline/gtractResampleDWIInPlace.xml
@@ -8,7 +8,7 @@
   <version>4.0.0</version>
   <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Modules:GTRACT</documentation-url>
   <license>http://mri.radiology.uiowa.edu/copyright/GTRACT-Copyright.txt</license>
-  <contributor>This tool was developed by Vincent Magnotta and Greg Harris.</contributor>
+  <contributor>This tool was developed by Vincent Magnotta, Greg Harris, Hans Johnson, and Joy Matsui.</contributor>
 
 
   <parameters>
@@ -39,6 +39,19 @@
       <default>0</default>
     </integer>
 
+  </parameters>
+
+  <parameters advanced="true">
+    <label>Main Parameters</label>
+
+    <integer-vector>
+      <name>paddedImageSize</name>
+      <longflag>paddedImageSize</longflag>
+      <label>Padded Image Size</label>
+      <description>Final image size of each diffusion weighted volume in the output image after image padding.</description>
+      <default>0,0,0</default>
+    </integer-vector>
+  
   </parameters>
 
   <parameters>


### PR DESCRIPTION
I figured it out. Padded DWI image is aligned with the resampled in place DWI because its origin has been adjusted relative to the padding.
