### PR TITLE
Increase the testing time for the BRAINSFit tests

### DIFF
--- a/BRAINSFit/TestSuite/CMakeLists.txt
+++ b/BRAINSFit/TestSuite/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(DART_TESTING_TIMEOUT 1000)
 
 MakeTestDriverFromSEMTool(BRAINSFit BRAINSFitTest.cxx)
 MakeTestDriverFromSEMTool(BRAINSFitEZ BRAINSFitEZTest.cxx)


### PR DESCRIPTION
Now the BRAINSFit_SyN\* tests are passed. They have sent to the dashboard:
http://testing.psychiatry.uiowa.edu/CDash/viewTest.php?onlypassed&buildid=35745
