### PR TITLE
GIT: added pep8 configuration file and appended to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ crash*
 .clang_complete
 *.orig
 .emacs.desktop
+*.config

--- a/AutoWorkup/.pep8
+++ b/AutoWorkup/.pep8
@@ -1,0 +1,3 @@
+[pep8]
+max-line-length = 120
+ignore = E302,E261


### PR DESCRIPTION
The command 'pep8' will read a .pep8 configuration file to decide what rules to ignore and other style preferences.  This file has some basic values included. 
