### PR TITLE
ERROR in Readme link

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ a new working repository at git@github.com:BRAINSia/BRAINSTools.git
 
 
 
-https://github.com/BRAINSia/BRAINSToolsw
+https://github.com/BRAINSia/BRAINSTools
 
 Please discontinue all work on the BRAINSStandAlone project.
 


### PR DESCRIPTION
Wrong link to redirect.

Accessed this page from Slicer Module documentation which would need an updated link:
http://www.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/BRAINSFit#References
